### PR TITLE
 adds jbrowse trackList.json sample file to the project 

### DIFF
--- a/extras/trackList.json.sample
+++ b/extras/trackList.json.sample
@@ -1,0 +1,39 @@
+{
+   "formatVersion" : 1,
+   "tracks" : [
+      {
+         "category" : "Reference sequence",
+         "chunkSize" : 20000,
+         "key" : "Reference sequence",
+         "label" : "DNA",
+         "seqType" : "dna",
+         "storeClass" : "JBrowse/Store/Sequence/StaticChunked",
+         "type" : "SequenceTrack",
+         "urlTemplate" : "seq/{refseq_dirpath}/{refseq}-"
+      },
+      {
+          "label":      "transcripts",
+          "key":        "Transcript track",
+          "type":         "JBrowse/View/Track/HTMLFeatures",
+          "storeClass": "JBrowse/Store/SeqFeature/REST",
+          "baseUrl":    "http://localhost:8000/machado/api/organism/4672581/jbrowse",
+          "query": {
+              "soType": "mRNA"
+          }
+      },
+      {
+          "label":      "CDS",
+          "key":        "CDS track",
+          "type":         "JBrowse/View/Track/HTMLFeatures",
+          "storeClass": "JBrowse/Store/SeqFeature/REST",
+          "baseUrl":    "http://localhost:8000/machado/api/organism/4672581/jbrowse",
+          "query": {
+              "soType": "CDS"
+          }
+      }
+   ],
+   "names": {
+       "type": "REST",
+       "url": "http://localhost:8000/machado/api/organism/4672581/jbrowse/names"
+   }
+}


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
