### PR TITLE
gets the reference sequence from the API

### DIFF
--- a/extras/trackList.json.sample
+++ b/extras/trackList.json.sample
@@ -1,39 +1,41 @@
 {
    "formatVersion" : 1,
+   "names" : {
+      "type" : "REST",
+      "url" : "http://localhost:8000/machado/api/organism/2981/jbrowse/names"
+   },
    "tracks" : [
+       {
+         "category": "Reference sequence",
+         "useAsRefSeqStore": true,
+         "label":      "ref_seq",
+         "key":        "REST Reference Sequence",
+         "type":       "JBrowse/View/Track/Sequence",
+         "storeClass": "JBrowse/Store/SeqFeature/REST",
+         "baseUrl":    "http://localhost:8000/machado/api/organism/2981/jbrowse",
+         "query": {
+            "soType": "reference"
+         }
+       },
       {
-         "category" : "Reference sequence",
-         "chunkSize" : 20000,
-         "key" : "Reference sequence",
-         "label" : "DNA",
-         "seqType" : "dna",
-         "storeClass" : "JBrowse/Store/Sequence/StaticChunked",
-         "type" : "SequenceTrack",
-         "urlTemplate" : "seq/{refseq_dirpath}/{refseq}-"
+         "baseUrl" : "http://localhost:8000/machado/api/organism/2981/jbrowse",
+         "key" : "Transcript track",
+         "label" : "transcripts",
+         "query" : {
+            "soType" : "mRNA"
+         },
+         "storeClass" : "JBrowse/Store/SeqFeature/REST",
+         "type" : "JBrowse/View/Track/HTMLFeatures"
       },
       {
-          "label":      "transcripts",
-          "key":        "Transcript track",
-          "type":         "JBrowse/View/Track/HTMLFeatures",
-          "storeClass": "JBrowse/Store/SeqFeature/REST",
-          "baseUrl":    "http://localhost:8000/machado/api/organism/4672581/jbrowse",
-          "query": {
-              "soType": "mRNA"
-          }
-      },
-      {
-          "label":      "CDS",
-          "key":        "CDS track",
-          "type":         "JBrowse/View/Track/HTMLFeatures",
-          "storeClass": "JBrowse/Store/SeqFeature/REST",
-          "baseUrl":    "http://localhost:8000/machado/api/organism/4672581/jbrowse",
-          "query": {
-              "soType": "CDS"
-          }
+         "baseUrl" : "http://localhost:8000/machado/api/organism/2981/jbrowse",
+         "key" : "CDS track",
+         "label" : "CDS",
+         "query" : {
+            "soType" : "CDS"
+         },
+         "storeClass" : "JBrowse/Store/SeqFeature/REST",
+         "type" : "JBrowse/View/Track/HTMLFeatures"
       }
-   ],
-   "names": {
-       "type": "REST",
-       "url": "http://localhost:8000/machado/api/organism/4672581/jbrowse/names"
-   }
+   ]
 }

--- a/machado/api/serializers.py
+++ b/machado/api/serializers.py
@@ -183,30 +183,40 @@ class JBrowseTranscriptSerializer(serializers.ModelSerializer):
     type = serializers.SerializerMethodField()
     uniqueID = serializers.SerializerMethodField()
     subfeatures = serializers.SerializerMethodField()
+    seq = serializers.SerializerMethodField()
 
     class Meta:
         """Meta."""
 
         model = Feature
         fields = ('uniqueID', 'name', 'type', 'start', 'end', 'strand',
-                  'subfeatures')
+                  'subfeatures', 'seq')
 
 #        fields = ('start', 'end')
 
     def get_start(self, obj):
         """Get the start location."""
-        feature_loc = obj.Featureloc_feature_Feature.first()
-        return feature_loc.fmin
+        try:
+            feature_loc = obj.Featureloc_feature_Feature.first()
+            return feature_loc.fmin
+        except AttributeError:
+            return 1
 
     def get_end(self, obj):
         """Get the end location."""
-        feature_loc = obj.Featureloc_feature_Feature.first()
-        return feature_loc.fmax
+        try:
+            feature_loc = obj.Featureloc_feature_Feature.first()
+            return feature_loc.fmax
+        except AttributeError:
+            return obj.seqlen
 
     def get_strand(self, obj):
         """Get the strand."""
-        feature_loc = obj.Featureloc_feature_Feature.first()
-        return feature_loc.strand
+        try:
+            feature_loc = obj.Featureloc_feature_Feature.first()
+            return feature_loc.strand
+        except AttributeError:
+            pass
 
     def get_type(self, obj):
         """Get the type."""
@@ -236,3 +246,7 @@ class JBrowseTranscriptSerializer(serializers.ModelSerializer):
             feat_dict['phase'] = feature_loc.phase
             result.append(feat_dict)
         return result
+
+    def get_seq(self, obj):
+        """Get the sequence."""
+        return obj.residues

--- a/machado/api/views.py
+++ b/machado/api/views.py
@@ -413,6 +413,11 @@ class NestedJBrowseTranscriptViewSet(viewsets.ReadOnlyModelViewSet):
             start = self.request.query_params.get('start') or 1
             end = self.request.query_params.get('end') or refseq.seqlen
 
+            if soType == "reference":
+                queryset = list()
+                queryset.append(refseq)
+                return queryset
+
             cvterm = Cvterm.objects.get(cv__name='sequence', name=soType)
 
             queryset = Feature.objects.filter(type_id=cvterm.cvterm_id)


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
