### PR TITLE
updates the API to generate the JBrowse required file: refSeqs.json

### DIFF
--- a/extras/trackList.json.sample
+++ b/extras/trackList.json.sample
@@ -1,8 +1,9 @@
 {
    "formatVersion" : 1,
+   "refSeqs": "http://localhost:8000/machado/api/organism/4672581/jbrowse/refSeqs.json",
    "names" : {
       "type" : "REST",
-      "url" : "http://localhost:8000/machado/api/organism/2981/jbrowse/names"
+      "url" : "http://localhost:8000/machado/api/organism/4672581/jbrowse/names"
    },
    "tracks" : [
        {
@@ -12,13 +13,13 @@
          "key":        "REST Reference Sequence",
          "type":       "JBrowse/View/Track/Sequence",
          "storeClass": "JBrowse/Store/SeqFeature/REST",
-         "baseUrl":    "http://localhost:8000/machado/api/organism/2981/jbrowse",
+         "baseUrl":    "http://localhost:8000/machado/api/organism/4672581/jbrowse",
          "query": {
             "soType": "reference"
          }
        },
       {
-         "baseUrl" : "http://localhost:8000/machado/api/organism/2981/jbrowse",
+         "baseUrl" : "http://localhost:8000/machado/api/organism/4672581/jbrowse",
          "key" : "Transcript track",
          "label" : "transcripts",
          "query" : {
@@ -28,7 +29,7 @@
          "type" : "JBrowse/View/Track/HTMLFeatures"
       },
       {
-         "baseUrl" : "http://localhost:8000/machado/api/organism/2981/jbrowse",
+         "baseUrl" : "http://localhost:8000/machado/api/organism/4672581/jbrowse",
          "key" : "CDS track",
          "label" : "CDS",
          "query" : {

--- a/machado/api/serializers.py
+++ b/machado/api/serializers.py
@@ -192,8 +192,6 @@ class JBrowseTranscriptSerializer(serializers.ModelSerializer):
         fields = ('uniqueID', 'name', 'type', 'start', 'end', 'strand',
                   'subfeatures', 'seq')
 
-#        fields = ('start', 'end')
-
     def get_start(self, obj):
         """Get the start location."""
         try:
@@ -250,3 +248,29 @@ class JBrowseTranscriptSerializer(serializers.ModelSerializer):
     def get_seq(self, obj):
         """Get the sequence."""
         return obj.residues
+
+
+class JBrowseRefseqSerializer(serializers.ModelSerializer):
+    """JBrowse transcript serializer."""
+
+    start = serializers.SerializerMethodField()
+    end = serializers.SerializerMethodField()
+    name = serializers.SerializerMethodField()
+
+    class Meta:
+        """Meta."""
+
+        model = Feature
+        fields = ('name', 'start', 'end')
+
+    def get_start(self, obj):
+        """Get the start location."""
+        return 1
+
+    def get_end(self, obj):
+        """Get the end location."""
+        return obj.seqlen
+
+    def get_name(self, obj):
+        """Get the name."""
+        return obj.uniquename

--- a/machado/api/urls.py
+++ b/machado/api/urls.py
@@ -57,6 +57,9 @@ organism_router.register(r'jbrowse/features/(?P<refseq>.+)',
 organism_router.register(r'jbrowse/names',
                          views.NestedJBrowseNamesViewSet,
                          base_name='jbrowse')
+organism_router.register(r'jbrowse/refSeqs.json',
+                         views.NestedJBrowseRefSeqsViewSet,
+                         base_name='jbrowse')
 
 urlpatterns = [
     url(r'', include_docs_urls(title='machado API')),

--- a/machado/api/views.py
+++ b/machado/api/views.py
@@ -17,6 +17,7 @@ from machado.api.serializers import FeatureSerializer, OrganismSerializer
 from machado.api.serializers import JBrowseTranscriptSerializer
 from machado.api.serializers import JBrowseNamesSerializer
 from machado.api.serializers import JBrowseGlobalSerializer
+from machado.api.serializers import JBrowseRefseqSerializer
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count
 from rest_framework import viewsets, filters
@@ -390,6 +391,31 @@ class NestedJBrowseNamesViewSet(viewsets.ReadOnlyModelViewSet):
             if startswith is not None:
                 queryset = queryset.filter(name__startswith=startswith)
         except KeyError:
+            pass
+
+        return queryset
+
+
+class NestedJBrowseRefSeqsViewSet(viewsets.ReadOnlyModelViewSet):
+    """API endpoint to JBrowse refSeqs.json."""
+
+    renderer_classes = (JSONRenderer, )
+    serializer_class = JBrowseRefseqSerializer
+
+    def get_queryset(self):
+        """Get queryset."""
+        try:
+
+            soType = 'chromosome'
+            cvterm = Cvterm.objects.get(cv__name='sequence', name=soType)
+
+            queryset = Feature.objects.filter(type_id=cvterm.cvterm_id)
+            queryset = queryset.filter(organism=self.kwargs['organism_pk'])
+            queryset = queryset.filter(is_obsolete=0)
+            queryset = queryset.order_by('uniquename')
+
+            queryset = queryset.filter(organism=self.kwargs['organism_pk'])
+        except ObjectDoesNotExist:
             pass
 
         return queryset


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
