### PR TITLE
refseq API: retrieve sequence type from GET

### DIFF
--- a/extras/trackList.json.sample
+++ b/extras/trackList.json.sample
@@ -1,6 +1,6 @@
 {
    "formatVersion" : 1,
-   "refSeqs": "http://localhost:8000/machado/api/jbrowse/refSeqs.json?organism=Arabidopsis thaliana",
+   "refSeqs": "http://localhost:8000/machado/api/jbrowse/refSeqs.json?soType=chromosome&organism=Arabidopsis thaliana",
    "names" : {
       "type" : "REST",
       "url" : "http://localhost:8000/machado/api/jbrowse/names",

--- a/machado/api/views.py
+++ b/machado/api/views.py
@@ -418,9 +418,13 @@ class JBrowseRefSeqsViewSet(viewsets.ReadOnlyModelViewSet):
             return
 
         try:
-            soType = 'chromosome'
-            cvterm = Cvterm.objects.get(cv__name='sequence', name=soType)
+            cvterm = Cvterm.objects.get(
+                cv__name='sequence',
+                name=self.request.query_params.get('soType'))
+        except (ObjectDoesNotExist, AttributeError):
+            return
 
+        try:
             queryset = Feature.objects.filter(type_id=cvterm.cvterm_id)
             queryset = queryset.filter(organism=organism)
             queryset = queryset.filter(is_obsolete=0)


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
