### PR TITLE
modifies sequenceloader to store the fasta description in feature.uniquename

### DIFF
--- a/machado/loaders/sequence.py
+++ b/machado/loaders/sequence.py
@@ -83,11 +83,15 @@ class SequenceLoader(object):
             if ignore_residues is True:
                 residues = ''
 
+            if seq_obj.description:
+                uniquename = seq_obj.description
+            else:
+                uniquename = seq_obj.id
+
             # storing feature
             feature = Feature(dbxref=dbxref,
                               organism=self.organism,
-                              name=seq_obj.description,
-                              uniquename=seq_obj.id,
+                              uniquename=uniquename,
                               residues=residues,
                               seqlen=len(seq_obj.seq),
                               md5checksum=m,

--- a/machado/tests/test_loaders_sequence.py
+++ b/machado/tests/test_loaders_sequence.py
@@ -42,8 +42,8 @@ class SequenceTest(TestCase):
                                  id='chr1',
                                  description='chromosome 1')
         test_seq_file.store_biopython_seq_record(test_seq_obj)
-        test_feature = Feature.objects.get(uniquename='chr1')
-        self.assertEqual('chromosome 1', test_feature.name)
+        test_feature = Feature.objects.get(uniquename='chromosome 1')
+        self.assertEqual('chromosome 1', test_feature.uniquename)
         self.assertEqual('acgtgtgtgcatgctagatcgatgcatgca',
                          test_feature.residues)
 
@@ -100,9 +100,9 @@ class SequenceTest(TestCase):
                                  id='chr2',
                                  description='chromosome 2')
         test_seq_file_pub.store_biopython_seq_record(test_seq_obj_pub)
-        test_feature_doi = Feature.objects.get(uniquename='chr2')
+        test_feature_doi = Feature.objects.get(uniquename='chromosome 2')
 
-        self.assertEqual('chromosome 2', test_feature_doi.name)
+        self.assertEqual('chromosome 2', test_feature_doi.uniquename)
         test_feature_pub_doi = FeaturePub.objects.get(
                 pub_id=test_bibtex3.pub_id)
         test_pub_dbxref_doi = PubDbxref.objects.get(


### PR DESCRIPTION
…quename

This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
