### PR TITLE
Load gff minor adjustments regarding using the db 'FASTA_source' for …

### DIFF
--- a/machado/loaders/feature.py
+++ b/machado/loaders/feature.py
@@ -220,8 +220,11 @@ class FeatureLoader(object):
                 raise ImportingError(e)
 
         try:
+            srcdb = Db.objects.get(name="FASTA_source")
+            srcdbxref = Dbxref.objects.get(accession=tabix_feature.contig,
+                                           db=srcdb)
             srcfeature = Feature.objects.get(
-                uniquename=tabix_feature.contig, organism=self.organism)
+                dbxref=srcdbxref, organism=self.organism)
         except ObjectDoesNotExist:
             raise ImportingError(
                 "Parent not found: {}. It's required to load "

--- a/machado/tests/test_api_jbrowse.py
+++ b/machado/tests/test_api_jbrowse.py
@@ -90,9 +90,9 @@ class JBrowseTests(APITestCase, URLPatternsTestCase):
         test_organism = Organism.objects.create(
             genus='Mus', species='musculus')
         # creates a srcfeature
-        test_db = Db.objects.create(name='test_db')
+        test_db = Db.objects.create(name='FASTA_source')
         test_dbxref = Dbxref.objects.create(
-                accession='test_dbxref', db=test_db)
+                accession='contig1', db=test_db)
         Feature.objects.create(
                     dbxref=test_dbxref, organism=test_organism, name='contig1',
                     type=test_cvterm_assembly, uniquename='contig1',
@@ -102,6 +102,8 @@ class JBrowseTests(APITestCase, URLPatternsTestCase):
 
         # creates features gene and exon
         class TabixFeature(object):
+            """mock parent features"""
+
             """mock tabix feature."""
 
         test_feature1 = TabixFeature()

--- a/machado/tests/test_loaders_feature.py
+++ b/machado/tests/test_loaders_feature.py
@@ -185,9 +185,9 @@ class FeatureTest(TestCase):
         test_organism = Organism.objects.create(
             genus='Mus', species='musculus')
         # create a srcfeature
-        test_db = Db.objects.create(name='test_db')
+        test_db = Db.objects.create(name='FASTA_source')
         test_dbxref = Dbxref.objects.create(
-                accession='test_dbxref', db=test_db)
+                accession='contig1', db=test_db)
         feature = Feature.objects.create(
                     dbxref=test_dbxref, organism=test_organism, name='contig1',
                     type=test_cvterm_assembly, uniquename='contig1',


### PR DESCRIPTION
…using parent dbxref accession.

This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
