### PR TITLE
empties urlpatterns if haystack is not installed/configured

### DIFF
--- a/machado/urls.py
+++ b/machado/urls.py
@@ -6,13 +6,20 @@
 
 """URLs."""
 
-from machado.views import common, feature, search
+from django.core.exceptions import ImproperlyConfigured
 from django.conf.urls import include, url
 
-urlpatterns = [
-    url(r'feature/', feature.FeatureView.as_view(), name='feature'),
-    url(r'data/', common.CommonView.as_view(), name='data_numbers'),
-    url(r'api/', include('machado.api.urls')),
-    url(r'find/', search.FeatureSearchView.as_view(), name='feature_search'),
-    url(r'^.*', common.HomeView.as_view(), name='home')
-]
+try:
+    from machado.views import common, feature, search
+
+    urlpatterns = [
+        url(r'feature/', feature.FeatureView.as_view(), name='feature'),
+        url(r'data/', common.CommonView.as_view(), name='data_numbers'),
+        url(r'api/', include('machado.api.urls')),
+        url(r'find/', search.FeatureSearchView.as_view(),
+            name='feature_search'),
+        url(r'^.*', common.HomeView.as_view(), name='home')
+    ]
+except ImproperlyConfigured as e:
+    urlpatterns = list()
+    print('Please install and configure haystack in order: {}'.format(e))

--- a/machado/views/search.py
+++ b/machado/views/search.py
@@ -23,5 +23,4 @@ class FeatureSearchView(FacetedSearchView):
         """Get context data."""
         context = super(FeatureSearchView, self).get_context_data(*args,
                                                                   **kwargs)
-        # print(context)
         return context


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
