### PR TITLE
 tests for management.commands.load_sequence_ontology 

### DIFF
--- a/machado/loaders/ontology.py
+++ b/machado/loaders/ontology.py
@@ -19,7 +19,7 @@ import re
 class OntologyLoader(object):
     """Ontology."""
 
-    def __init__(self, cv_name: str, cv_definition: str=None) -> None:
+    def __init__(self, cv_name: str, cv_definition: str = None) -> None:
         """Invoke all validations."""
         # Save the name and definition to the Cv model
         try:
@@ -196,7 +196,7 @@ class OntologyLoader(object):
     def store_term(self,
                    n: str,
                    data: Dict[str, Any],
-                   lock: Optional[Lock]=None) -> None:
+                   lock: Optional[Lock] = None) -> None:
         """Store the ontology terms."""
         # Save the term to the Dbxref model
         aux_db, aux_accession = n.split(':')
@@ -209,13 +209,16 @@ class OntologyLoader(object):
             cv, created = Cv.objects.get_or_create(name=data['namespace'])
         else:
             cv = self.cv
-        cvterm, created = Cvterm.objects.get_or_create(
-            cv=cv,
-            name=data['name'],
-            definition='',
-            dbxref=dbxref,
-            is_obsolete=0,
-            is_relationshiptype=0)
+        try:
+            cvterm, created = Cvterm.objects.get_or_create(
+                cv=cv,
+                name=data['name'],
+                definition='',
+                dbxref=dbxref,
+                is_obsolete=0,
+                is_relationshiptype=0)
+        except KeyError as e:
+            raise ImportingError("{}\nError loading {}".format(e, data))
 
         # Definitions usually contain recurrent dbxrefs
         # will sometimes break since they're running concurrently with
@@ -296,7 +299,7 @@ class OntologyLoader(object):
     def process_cvterm_def(self,
                            cvterm: Cvterm,
                            definition: str,
-                           is_for_definition: int=1) -> None:
+                           is_for_definition: int = 1) -> None:
         """Process defition to obtain cvterms."""
         text = ''
 
@@ -346,7 +349,7 @@ class OntologyLoader(object):
     def process_cvterm_xref(self,
                             cvterm: Cvterm,
                             xref: str,
-                            is_for_definition: int=0) -> None:
+                            is_for_definition: int = 0) -> None:
         """Process cvterm_xref."""
         if xref:
 

--- a/machado/management/commands/load_sequence_ontology.py
+++ b/machado/management/commands/load_sequence_ontology.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
                             "The-Sequence-Ontology/SO-Ontologies",
                             required=True, type=str)
 
-    def handle(self, file: str, verbosity: int=1, **options):
+    def handle(self, file: str, verbosity: int = 1, **options):
         """Execute the main function."""
         try:
             FileValidator().validate(file)
@@ -50,19 +50,23 @@ class Command(BaseCommand):
             self.stdout.write('Loading typedefs')
 
         # Load typedefs as Dbxrefs and Cvterm
-        for typedef in tqdm(G.graph['typedefs']):
+        for typedef in tqdm(G.graph['typedefs'],
+                            disable=False if verbosity > 0 else True):
             ontology.store_type_def(typedef)
 
         if verbosity > 0:
             self.stdout.write('Loading terms')
 
-        for n, data in tqdm(G.nodes(data=True)):
+        for n, data in tqdm(G.nodes(data=True),
+                            disable=False if verbosity > 0 else True):
             ontology.store_term(n, data)
 
         if verbosity > 0:
             self.stdout.write('Loading relationships')
 
-        for u, v, type in tqdm(G.edges(keys=True)):
+        for u, v, type in tqdm(G.edges(keys=True),
+                               disable=False if verbosity > 0 else True):
             ontology.store_relationship(u, v, type)
 
-        self.stdout.write(self.style.SUCCESS('Done'))
+        if verbosity > 0:
+            self.stdout.write(self.style.SUCCESS('Done'))

--- a/machado/tests/data/so_fake.obo
+++ b/machado/tests/data/so_fake.obo
@@ -1,0 +1,54 @@
+format-version: 1.2
+data-version: so.obo(fake)
+date: 15:12:2017 11:11
+saved-by: nicole
+auto-generated-by: OBO-Edit 2.3.1
+subsetdef: biosapiens "biosapiens protein feature ontology"
+subsetdef: DBVAR "database of genomic structural variation"
+subsetdef: SOFA "SO feature annotation"
+synonymtypedef: aa1 "amino acid 1 letter code"
+synonymtypedef: aa3 "amino acid 3 letter code"
+synonymtypedef: AAMOD "amino acid modification"
+synonymtypedef: BS "biosapiens"
+synonymtypedef: dbsnp "dbsnp variant terms"
+synonymtypedef: dbvar "DBVAR"
+synonymtypedef: ebi_variants "ensembl variant terms"
+synonymtypedef: RNAMOD "RNA modification" EXACT
+synonymtypedef: VAR "variant annotation term"
+default-namespace: sequence
+ontology: so
+
+[Term]
+id: SO:0000000
+name: Sequence_Ontology
+subset: SOFA
+is_obsolete: true
+
+[Term]
+id: SO:0000012
+name: scRNA_primary_transcript
+def: "The primary transcript of any one of several small cytoplasmic RNA molecules present in the cytoplasm and sometimes nucleus of a Eukaryote." [http://www.ebi.ac.uk/embl/WebFeat/align/scRNA_s.html]
+synonym: "scRNA primary transcript" EXACT []
+synonym: "small_cytoplasmic_RNA" RELATED []
+
+[Term]
+id: SO:0000013
+name: scRNA
+def: "A small non coding RNA sequence, present in the cytoplasm." [SO:ke]
+subset: SOFA
+xref: http://web.site/FakeData "wiki"
+synonym: "small cytoplasmic RNA" EXACT []
+comment: Fake term data.
+alt_id: SO:0000012
+relationship: derives_from SO:0000012 ! scRNA_primary_transcript
+
+[Typedef]
+id: derives_from
+name: derives_from
+def: "testing def loading." [PMID:999090909]
+comment: Fake typedef data.
+xref: FAKE:0123
+is_transitive: true
+is_class_level: true
+is_metadata_tag: true
+is_symmetric: true

--- a/machado/tests/data/so_trunc.obo
+++ b/machado/tests/data/so_trunc.obo
@@ -113,6 +113,17 @@ subset: SOFA
 synonym: "INSDC_feature:gene" EXACT []
 xref: http://en.wikipedia.org/wiki/Gene "wiki"
 
+[Term]
+id: SO:0000104
+name: polypeptide
+alt_id: SO:0000358
+def: "A sequence of amino acids linked by peptide bonds which may lack appreciable tertiary structure and may not be liable to irreversible denaturation." [SO:ma]
+comment: This term is mapped to MGED. Do not obsolete without consulting MGED ontology. The term 'protein' was merged with 'polypeptide'. Although 'protein' was a sequence_attribute and therefore meant to describe the quality rather than an actual feature, it was being used erroneously. It is replaced by 'peptidyl' as the polymer attribute.
+subset: SOFA
+synonym: "protein" EXACT []
+xref: http://en.wikipedia.org/wiki/Polypeptide "wiki"
+relationship: derives_from SO:0000316 ! CDS
+
 [Typedef]
 id: part_of
 name: part_of
@@ -130,3 +141,10 @@ created_by: kareneilbeck
 creation_date: 2009-08-19T12:09:59Z
 is_transitive: true
 is_symmetric: true
+
+[Typedef]
+id: derives_from
+name: derives_from
+subset: SOFA
+is_transitive: true
+

--- a/machado/tests/data/so_trunc.obo
+++ b/machado/tests/data/so_trunc.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: so.obo(fake)
-date: 15:12:2017 11:11
+data-version: so.obo(truncated)
+date: 07:02:2018 12:02
 saved-by: nicole
 auto-generated-by: OBO-Edit 2.3.1
 subsetdef: biosapiens "biosapiens protein feature ontology"
@@ -25,30 +25,108 @@ subset: SOFA
 is_obsolete: true
 
 [Term]
-id: SO:0000012
-name: scRNA_primary_transcript
-def: "The primary transcript of any one of several small cytoplasmic RNA molecules present in the cytoplasm and sometimes nucleus of a Eukaryote." [http://www.ebi.ac.uk/embl/WebFeat/align/scRNA_s.html]
-synonym: "scRNA primary transcript" EXACT []
-synonym: "small_cytoplasmic_RNA" RELATED []
+id: SO:0000001
+name: region
+def: "A sequence_feature with an extent greater than zero. A nucleotide region is composed of bases and a polypeptide region is composed of amino acids." [SO:ke]
+subset: SOFA
+synonym: "sequence" EXACT []
 
 [Term]
-id: SO:0000013
-name: scRNA
-def: "A small non coding RNA sequence, present in the cytoplasm." [SO:ke]
+id: SO:0000039
+name: match_part
+def: "A part of a match, for example an hsp from blast is a match_part." [SO:ke]
 subset: SOFA
-xref: http://web.site/FakeData "wiki"
-synonym: "small cytoplasmic RNA" EXACT []
-comment: Fake term data.
-alt_id: SO:0000012
-relationship: derives_from SO:0000012 ! scRNA_primary_transcript
+synonym: "match part" EXACT []
+
+[Term]
+id: SO:0000147
+name: exon
+def: "A region of the transcript sequence within a gene which is not removed from the primary RNA transcript by RNA splicing." [SO:ke]
+comment: This term is mapped to MGED. Do not obsolete without consulting MGED ontology.
+subset: SOFA
+synonym: "INSDC_feature:exon" EXACT []
+xref: http://en.wikipedia.org/wiki/Exon "wiki"
+
+[Term]
+id: SO:0000204
+name: five_prime_UTR
+def: "A region at the 5' end of a mature transcript (preceding the initiation codon) that is not translated into a protein." [http://www.ebi.ac.uk/embl/Documentation/FT_definitions/feature_table.html]
+subset: SOFA
+synonym: "5' UTR" EXACT []
+synonym: "five prime UTR" EXACT []
+synonym: "five_prime_untranslated_region" EXACT []
+synonym: "INSDC_feature:5'UTR" EXACT []
+xref: http://en.wikipedia.org/wiki/5'_UTR "wiki"
+
+[Term]
+id: SO:0000205
+name: three_prime_UTR
+def: "A region at the 3' end of a mature transcript (following the stop codon) that is not translated into a protein." [http://www.ebi.ac.uk/embl/Documentation/FT_definitions/feature_table.html]
+subset: SOFA
+synonym: "INSDC_feature:3'UTR" EXACT []
+synonym: "three prime untranslated region" EXACT []
+synonym: "three prime UTR" EXACT []
+xref: http://en.wikipedia.org/wiki/Three_prime_untranslated_region "wiki"
+
+[Term]
+id: SO:0000234
+name: mRNA
+def: "Messenger RNA is the intermediate molecule between DNA and protein. It includes UTR and coding sequences. It does not contain introns." [SO:ma]
+comment: An mRNA does not contain introns as it is a processed_transcript. The equivalent kind of primary_transcript is protein_coding_primary_transcript (SO:0000120) which may contain introns. This term is mapped to MGED. Do not obsolete without consulting MGED ontology.
+subset: SOFA
+synonym: "INSDC_feature:mRNA" EXACT []
+synonym: "messenger RNA" EXACT []
+synonym: "protein_coding_transcript" EXACT []
+xref: http://en.wikipedia.org/wiki/MRNA "wiki"
+xref: http://www.gencodegenes.org/gencode_biotypes.html "GENCODE"
+
+[Term]
+id: SO:0000316
+name: CDS
+def: "A contiguous sequence which begins with, and includes, a start codon and ends with, and includes, a stop codon." [SO:ma]
+subset: SOFA
+synonym: "coding sequence" EXACT []
+synonym: "coding_sequence" EXACT []
+synonym: "INSDC_feature:CDS" EXACT []
+
+[Term]
+id: SO:0000340
+name: chromosome
+def: "Structural unit composed of a nucleic acid molecule which controls its own replication through the interaction of specific proteins at one or more origins of replication." [SO:ma]
+comment: This term is mapped to MGED. Do not obsolete without consulting MGED ontology.
+subset: SOFA
+xref: http://en.wikipedia.org/wiki/Chromosome "wiki"
+
+[Term]
+id: SO:0000349
+name: protein_match
+def: "A match against a protein sequence." [SO:ke]
+subset: SOFA
+synonym: "protein match" EXACT []
+
+[Term]
+id: SO:0000704
+name: gene
+def: "A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions." [SO:immuno_workshop]
+comment: This term is mapped to MGED. Do not obsolete without consulting MGED ontology. A gene may be considered as a unit of inheritance.
+subset: SOFA
+synonym: "INSDC_feature:gene" EXACT []
+xref: http://en.wikipedia.org/wiki/Gene "wiki"
 
 [Typedef]
-id: derives_from
-name: derives_from
-def: "testing def loading." [PMID:999090909]
-comment: Fake typedef data.
-xref: FAKE:0123
+id: part_of
+name: part_of
+def: "X part_of Y if X is a subregion of Y." [http://precedings.nature.com/documents/3495/version/1]
+comment: Example: amino_acid part_of polypeptide.
+subset: SOFA
 is_transitive: true
-is_class_level: true
-is_metadata_tag: true
+
+[Typedef]
+id: translation_of
+name: translation_of
+def: "X is translation of Y." [http://precedings.nature.com]
+comment: Example: Polypeptide translation_of CDS.
+created_by: kareneilbeck
+creation_date: 2009-08-19T12:09:59Z
+is_transitive: true
 is_symmetric: true

--- a/machado/tests/test_commands_insert_organism.py
+++ b/machado/tests/test_commands_insert_organism.py
@@ -4,7 +4,7 @@
 # license. Please see the LICENSE.txt and README.md files that should
 # have been included as part of this package for licensing information.
 
-"""Tests loader sequence."""
+"""Tests commands insert organism."""
 
 from django.test import TestCase
 from django.core.exceptions import ObjectDoesNotExist

--- a/machado/tests/test_commands_load_sequence_ontology.py
+++ b/machado/tests/test_commands_load_sequence_ontology.py
@@ -8,6 +8,7 @@
 
 import os
 from django.test import TestCase
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from machado.models import Cvterm
@@ -16,9 +17,9 @@ from machado.models import Cvterm
 class CommandTest(TestCase):
     """Tests Loaders - SequenceLoader."""
 
-    def test_insert_organism(self):
+    def test_load_sequence_ontology(self):
         """Tests - insert organism."""
-        # test insert organism
+        # test load sequence ontology
         directory = os.path.dirname(os.path.abspath(__file__))
         file = os.path.join(directory, 'data', 'so_trunc.obo')
         call_command("load_sequence_ontology",
@@ -30,3 +31,17 @@ class CommandTest(TestCase):
         with self.assertRaises(CommandError):
             call_command("load_sequence_ontology",
                          "--file=does_not_exist")
+
+        # test remove sequence ontology
+        call_command("remove_ontology",
+                     "--name=sequence",
+                     "--verbosity=0")
+        with self.assertRaises(ObjectDoesNotExist):
+            Cvterm.objects.get(name='gene')
+
+        # test remove ontology does not exist
+        with self.assertRaisesMessage(
+                CommandError, 'Cannot remove \'sequence\' (not registered)'):
+            call_command("remove_ontology",
+                         "--name=sequence",
+                         "--verbosity=0")

--- a/machado/tests/test_commands_load_sequence_ontology.py
+++ b/machado/tests/test_commands_load_sequence_ontology.py
@@ -41,7 +41,8 @@ class CommandTest(TestCase):
 
         # test remove ontology does not exist
         with self.assertRaisesMessage(
-                CommandError, 'Cannot remove \'sequence\' (not registered)'):
+                    CommandError,
+                    'Cannot remove \'sequence\' (not registered)'):
             call_command("remove_ontology",
                          "--name=sequence",
                          "--verbosity=0")

--- a/machado/tests/test_commands_load_sequence_ontology.py
+++ b/machado/tests/test_commands_load_sequence_ontology.py
@@ -8,7 +8,6 @@
 
 import os
 from django.test import TestCase
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from machado.models import Cvterm
@@ -26,3 +25,8 @@ class CommandTest(TestCase):
                      "--file={}".format(file),
                      "--verbosity=0")
         self.assertTrue(Cvterm.objects.get(name='gene'))
+
+        # test ImportingError
+        with self.assertRaises(CommandError):
+            call_command("load_sequence_ontology",
+                         "--file=does_not_exist")

--- a/machado/tests/test_commands_load_sequence_ontology.py
+++ b/machado/tests/test_commands_load_sequence_ontology.py
@@ -1,0 +1,28 @@
+# Copyright 2018 by Embrapa.  All rights reserved.
+#
+# This code is part of the machado distribution and governed by its
+# license. Please see the LICENSE.txt and README.md files that should
+# have been included as part of this package for licensing information.
+
+"""Tests command load sequence ontology."""
+
+import os
+from django.test import TestCase
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from machado.models import Cvterm
+
+
+class CommandTest(TestCase):
+    """Tests Loaders - SequenceLoader."""
+
+    def test_insert_organism(self):
+        """Tests - insert organism."""
+        # test insert organism
+        directory = os.path.dirname(os.path.abspath(__file__))
+        file = os.path.join(directory, 'data', 'so_trunc.obo')
+        call_command("load_sequence_ontology",
+                     "--file={}".format(file),
+                     "--verbosity=0")
+        self.assertTrue(Cvterm.objects.get(name='gene'))

--- a/machado/tests/test_loaders_ontology.py
+++ b/machado/tests/test_loaders_ontology.py
@@ -231,7 +231,7 @@ class OntologyTest(TestCase):
     def test_store_type_def(self):
         """Tests - store type_def."""
         directory = os.path.dirname(os.path.abspath(__file__))
-        file = os.path.join(directory, 'data', 'so_trunc.obo')
+        file = os.path.join(directory, 'data', 'so_fake.obo')
 
         with open(file) as obo_file:
             G = obonet.read_obo(obo_file)
@@ -285,7 +285,7 @@ class OntologyTest(TestCase):
     def test_store_term(self):
         """Tests - store term."""
         directory = os.path.dirname(os.path.abspath(__file__))
-        file = os.path.join(directory, 'data', 'so_trunc.obo')
+        file = os.path.join(directory, 'data', 'so_fake.obo')
 
         with open(file) as obo_file:
             G = obonet.read_obo(obo_file)
@@ -325,7 +325,7 @@ class OntologyTest(TestCase):
     def test_store_relationship(self):
         """Tests - store relationship."""
         directory = os.path.dirname(os.path.abspath(__file__))
-        file = os.path.join(directory, 'data', 'so_trunc.obo')
+        file = os.path.join(directory, 'data', 'so_fake.obo')
 
         with open(file) as obo_file:
             G = obonet.read_obo(obo_file)


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
