### PR TITLE
load_coexpression corrections (tqdm totals get file's number of lines)

### DIFF
--- a/machado/management/commands/load_coexpression_clusters.py
+++ b/machado/management/commands/load_coexpression_clusters.py
@@ -7,6 +7,7 @@
 """Load clusters of coexpression data from LSTRAP outfile mcl.clusters.txt."""
 
 from machado.loaders.common import FileValidator, FieldsValidator
+from machado.loaders.common import get_num_lines
 from machado.loaders.coexpression import CoexpressionLoader
 from machado.loaders.exceptions import ImportingError
 from django.db.utils import IntegrityError
@@ -76,7 +77,7 @@ The features need to be loaded previously or won't be registered."""
         # arbitrary naming...
         value = "MCL_CLUSTER"
         # each line is an orthologous group
-        for line in tqdm(clusters, total=len(clusters)):
+        for line in tqdm(clusters, total=get_num_lines(file)):
             # a pair of features plus the PCC value
             fields = re.split(r'\s+', line.rstrip())
             nfields = len(fields)

--- a/machado/management/commands/load_coexpression_pairs.py
+++ b/machado/management/commands/load_coexpression_pairs.py
@@ -7,6 +7,7 @@
 """Load coexpression data from LSTRAP output file pcc.mcl.txt."""
 
 from machado.loaders.common import FileValidator, FieldsValidator
+from machado.loaders.common import get_num_lines
 from machado.loaders.coexpression import CoexpressionLoader
 from machado.loaders.exceptions import ImportingError
 from django.db.utils import IntegrityError
@@ -75,7 +76,7 @@ The feature pairs from columns 1 and 2 need to be loaded previously."""
         pool = ThreadPoolExecutor(max_workers=cpu)
         tasks = list()
         # each line is an orthologous group
-        for line in tqdm(pairs, total=len(pairs)):
+        for line in tqdm(pairs, total=get_num_lines(file)):
             # a pair of features plus the PCC value
             nfields = 3
             fields = re.split(r'\s+', line.rstrip())


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
