### PR TITLE
fix: FASTA_source to FASTA_SOURCE

### DIFF
--- a/machado/tests/test_api_jbrowse.py
+++ b/machado/tests/test_api_jbrowse.py
@@ -94,7 +94,7 @@ class JBrowseTests(APITestCase, URLPatternsTestCase):
         test_organism = Organism.objects.create(
             genus='Mus', species='musculus')
         # creates a srcfeature
-        test_db = Db.objects.create(name='FASTA_source')
+        test_db = Db.objects.create(name='FASTA_SOURCE')
         test_dbxref = Dbxref.objects.create(
                 accession='contig1', db=test_db)
         Feature.objects.create(

--- a/machado/tests/test_loaders_feature.py
+++ b/machado/tests/test_loaders_feature.py
@@ -184,7 +184,7 @@ class FeatureTest(TestCase):
         test_organism = Organism.objects.create(
             genus='Mus', species='musculus')
         # create a srcfeature
-        test_db = Db.objects.create(name='FASTA_source')
+        test_db = Db.objects.create(name='FASTA_SOURCE')
         test_dbxref = Dbxref.objects.create(
                 accession='contig1', db=test_db)
         feature = Feature.objects.create(

--- a/machado/tests/test_loaders_similarity.py
+++ b/machado/tests/test_loaders_similarity.py
@@ -75,7 +75,7 @@ class SimilarityTest(TestCase):
             is_obsolete=0, is_relationshiptype=0)
 
         # creating test features
-        feature_db = Db.objects.create(name='FASTA_source')
+        feature_db = Db.objects.create(name='FASTA_SOURCE')
         feature_dbxref1 = Dbxref.objects.create(
             db=feature_db, accession='feat1')
         feature_dbxref2 = Dbxref.objects.create(


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
