### PR TITLE
 FASTA: export feature only if it has residues 

### DIFF
--- a/machado/templates/search_result.html
+++ b/machado/templates/search_result.html
@@ -24,9 +24,9 @@
                     <h3>Results</h3>
                 </div>
                 <div class="col text-right">
-                    <a class="fas fa-download" href="{% url 'feature_search_export' %}?{{ request.GET.urlencode }}&export=tsv" title="Download TSV"></a>
+                    <a class="fas fa-download" href="{% url 'feature_search_export' %}?{{ request.GET.urlencode }}&export=tsv" title="Download TSV" onclick="return confirm('Download results in TSV format')"></a>
                     {% if facets.fields|get_item:'so_term'|length == 1 %}
-                        <a class="fas fa-download" href="{% url 'feature_search_export' %}?{{ request.GET.urlencode }}&export=fasta" title="Download FASTA"></a>
+                    <a class="fas fa-download" href="{% url 'feature_search_export' %}?{{ request.GET.urlencode }}&export=fasta" title="Download FASTA" onclick="return confirm('Download results in FASTA format')"></a>
                     {% endif %}
                 </div>
             </div>

--- a/machado/templates/search_result.out
+++ b/machado/templates/search_result.out
@@ -1,6 +1,6 @@
 {% if file_format == 'tsv' %}SO term	Feature ID	Display	Orthologous group
 {% for result in object_list %}{{ result.object.type.name }}	{{ result.uniquename }}	{{ result.object.get_display|default_if_none:'' }}	{{ result.object.get_orthologs_groups|safe|default_if_none:'' }}{% endfor %}
-{% elif file_format == 'fasta' %}{% for result in object_list %}>{{ result.object.dbxref.accession }} {{ result.object.get_display|default_if_none:'' }}
+{% elif file_format == 'fasta' %}{% for result in object_list %}{% if result.object.residues %}>{{ result.object.dbxref.accession }} {{ result.object.get_display|default_if_none:'' }}
 {{ result.object.residues }}
-{% endfor %}
+{% endif %}{% endfor %}
 {% else %}Unknown format.{% endif %}

--- a/machado/views/search.py
+++ b/machado/views/search.py
@@ -66,16 +66,12 @@ class FeatureSearchExportView(FacetedSearchView):
         self.file_format = file_format
         context['file_format'] = file_format
 
-#        filename = 'machado_search_results.{}'.format(file_format)
-#        response['Content-Disposition'] = 'attachment; filename="{}"'.format(
-#            filename)
         return context
 
     def dispatch(self, *args, **kwargs):
         """Dispatch."""
         response = super(FeatureSearchExportView, self).dispatch(
             *args, **kwargs)
-
         filename = 'machado_search_results.{}'.format(self.file_format)
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(
             filename)


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
