### PR TITLE
 Modifications to store_feature_groups store_feature_pairs: soterm is now optional

### DIFF
--- a/machado/loaders/feature.py
+++ b/machado/loaders/feature.py
@@ -492,12 +492,12 @@ class FeatureLoader(object):
         FeaturePub.objects.get_or_create(feature_id=feature_id, pub=pub_obj)
 
     def store_feature_pairs(
-            self,
-            pair: list,
-            term: Union[str, Cvterm],
-            soterm: str = 'mRNA',
-            value: str = None,
-            cache: int = 0
+        self,
+        pair: list,
+        term: Union[str, Cvterm],
+        soterm: str = "mRNA",
+        value: str = None,
+        cache: int = 0,
     ) -> None:
         """Store Feature Relationship Pairs."""
         # only cvterm_id allowed
@@ -528,12 +528,12 @@ class FeatureLoader(object):
             raise ImportingError(e)
 
     def store_feature_groups(
-            self,
-            group: list,
-            term: Union[int, Cvterm],
-            soterm: str = 'mRNA',
-            value: str = None,
-            cache: int = 0
+        self,
+        group: list,
+        term: Union[int, Cvterm],
+        soterm: str = "mRNA",
+        value: str = None,
+        cache: int = 0,
     ) -> None:
         """Store Feature Relationship Groups."""
         # only cvterm_id allowed

--- a/machado/loaders/feature.py
+++ b/machado/loaders/feature.py
@@ -492,7 +492,12 @@ class FeatureLoader(object):
         FeaturePub.objects.get_or_create(feature_id=feature_id, pub=pub_obj)
 
     def store_feature_pairs(
-        self, pair: list, term: Union[str, Cvterm], value: str = None, cache: int = 0
+            self,
+            pair: list,
+            term: Union[str, Cvterm],
+            soterm: str = 'mRNA',
+            value: str = None,
+            cache: int = 0
     ) -> None:
         """Store Feature Relationship Pairs."""
         # only cvterm_id allowed
@@ -500,7 +505,6 @@ class FeatureLoader(object):
             cvterm_id = term.cvterm_id
         else:
             cvterm_id = term
-        soterm = "polypeptide"
         # lets get feature_ids from the pair
         try:
             subject_id = retrieve_feature_id(accession=pair[0], soterm=soterm)
@@ -524,7 +528,12 @@ class FeatureLoader(object):
             raise ImportingError(e)
 
     def store_feature_groups(
-        self, group: list, term: Union[int, Cvterm], value: str = None, cache: int = 0
+            self,
+            group: list,
+            term: Union[int, Cvterm],
+            soterm: str = 'mRNA',
+            value: str = None,
+            cache: int = 0
     ) -> None:
         """Store Feature Relationship Groups."""
         # only cvterm_id allowed
@@ -536,7 +545,7 @@ class FeatureLoader(object):
         feature_id_list = list(
             Feature.objects.filter(
                 type__cv__name="sequence",
-                type__name="polypeptide",
+                type__name=soterm,
                 dbxref__accession__in=group,
                 dbxref__db__name__in=["GFF_SOURCE", "FASTA_SOURCE"],
             )

--- a/machado/management/commands/load_coexpression_clusters.py
+++ b/machado/management/commands/load_coexpression_clusters.py
@@ -42,7 +42,7 @@ The features need to be loaded previously or won't be registered."""
             "--soterm",
             help="sequence ontology term 'e.g. mRNA'",
             required=False,
-            type=str
+            type=str,
         )
         parser.add_argument(
             "--organism",
@@ -53,13 +53,13 @@ The features need to be loaded previously or won't be registered."""
         parser.add_argument("--cpu", help="Number of threads", default=1, type=int)
 
     def handle(
-            self,
-            file: str,
-            organism: str,
-            soterm: str = 'mRNA',
-            cpu: int = 1,
-            verbosity: int = 0,
-            **options
+        self,
+        file: str,
+        organism: str,
+        soterm: str = "mRNA",
+        cpu: int = 1,
+        verbosity: int = 0,
+        **options
     ):
         """Execute the main function."""
         filename = os.path.basename(file)

--- a/machado/management/commands/load_coexpression_clusters.py
+++ b/machado/management/commands/load_coexpression_clusters.py
@@ -39,6 +39,12 @@ The features need to be loaded previously or won't be registered."""
             "--file", help="'mcl.clusters.txt' File", required=True, type=str
         )
         parser.add_argument(
+            "--soterm",
+            help="sequence ontology term 'e.g. mRNA'",
+            required=False,
+            type=str
+        )
+        parser.add_argument(
             "--organism",
             help="Scientific name (e.g.: 'Oryza sativa')",
             required=True,
@@ -47,7 +53,13 @@ The features need to be loaded previously or won't be registered."""
         parser.add_argument("--cpu", help="Number of threads", default=1, type=int)
 
     def handle(
-        self, file: str, organism: str, cpu: int = 1, verbosity: int = 0, **options
+            self,
+            file: str,
+            organism: str,
+            soterm: str = 'mRNA',
+            cpu: int = 1,
+            verbosity: int = 0,
+            **options
     ):
         """Execute the main function."""
         filename = os.path.basename(file)
@@ -108,6 +120,7 @@ The features need to be loaded previously or won't be registered."""
                 pool.submit(
                     featureloader.store_feature_groups,
                     group=fields,
+                    soterm=soterm,
                     term=cvterm_cluster.cvterm_id,
                     value=name,
                 )

--- a/machado/management/commands/load_coexpression_pairs.py
+++ b/machado/management/commands/load_coexpression_pairs.py
@@ -35,28 +35,24 @@ The feature pairs from columns 1 and 2 need to be loaded previously."""
     def add_arguments(self, parser):
         """Define the arguments."""
         parser.add_argument(
-            "--file",
-            help="'pcc.mcl.txt' File",
-            required=True,
-            type=str
+            "--file", help="'pcc.mcl.txt' File", required=True, type=str
         )
         parser.add_argument(
             "--soterm",
             help="sequence ontology term 'e.g. mRNA'",
             required=False,
-            type=str
+            type=str,
         )
-        parser.add_argument("--cpu",
-                            help="Number of threads",
-                            default=1,
-                            type=int)
+        parser.add_argument("--cpu", help="Number of threads", default=1, type=int)
 
-    def handle(self,
-               file: str,
-               cpu: int = 1,
-               soterm: str = 'mRNA',
-               verbosity: int = 0,
-               **options):
+    def handle(
+        self,
+        file: str,
+        cpu: int = 1,
+        soterm: str = "mRNA",
+        verbosity: int = 0,
+        **options
+    ):
         """Execute the main function."""
         filename = os.path.basename(file)
         if verbosity > 0:

--- a/machado/management/commands/load_coexpression_pairs.py
+++ b/machado/management/commands/load_coexpression_pairs.py
@@ -35,11 +35,28 @@ The feature pairs from columns 1 and 2 need to be loaded previously."""
     def add_arguments(self, parser):
         """Define the arguments."""
         parser.add_argument(
-            "--file", help="'pcc.mcl.txt' File", required=True, type=str
+            "--file",
+            help="'pcc.mcl.txt' File",
+            required=True,
+            type=str
         )
-        parser.add_argument("--cpu", help="Number of threads", default=1, type=int)
+        parser.add_argument(
+            "--soterm",
+            help="sequence ontology term 'e.g. mRNA'",
+            required=False,
+            type=str
+        )
+        parser.add_argument("--cpu",
+                            help="Number of threads",
+                            default=1,
+                            type=int)
 
-    def handle(self, file: str, cpu: int = 1, verbosity: int = 0, **options):
+    def handle(self,
+               file: str,
+               cpu: int = 1,
+               soterm: str = 'mRNA',
+               verbosity: int = 0,
+               **options):
         """Execute the main function."""
         filename = os.path.basename(file)
         if verbosity > 0:
@@ -79,6 +96,7 @@ The feature pairs from columns 1 and 2 need to be loaded previously."""
                     pool.submit(
                         featureloader.store_feature_pairs,
                         pair=fields,
+                        soterm=soterm,
                         term=cvterm_corel,
                         value=value,
                     )

--- a/machado/management/commands/load_orthomcl.py
+++ b/machado/management/commands/load_orthomcl.py
@@ -60,6 +60,10 @@ The feature members need to be loaded previously."""
             is_obsolete=0,
             is_relationshiptype=0,
         )
+
+        # hardcoded as orthomcl uses protein input
+        soterm = 'polypeptide'
+
         source = "null"
         featureloader = FeatureLoader(source=source, filename=filename)
         # each line is an orthologous group
@@ -84,6 +88,7 @@ The feature members need to be loaded previously."""
                 tasks.append(
                     pool.submit(
                         featureloader.store_feature_groups,
+                        soterm=soterm,
                         group=members,
                         term=cvterm_cluster.cvterm_id,
                         value=name,

--- a/machado/management/commands/load_orthomcl.py
+++ b/machado/management/commands/load_orthomcl.py
@@ -62,7 +62,7 @@ The feature members need to be loaded previously."""
         )
 
         # hardcoded as orthomcl uses protein input
-        soterm = 'polypeptide'
+        soterm = "polypeptide"
 
         source = "null"
         featureloader = FeatureLoader(source=source, filename=filename)

--- a/machado/tests/test_loaders_coexpression.py
+++ b/machado/tests/test_loaders_coexpression.py
@@ -134,7 +134,7 @@ class CoexpressionTest(TestCase):
         # dummy coexpression variables
         test_filename = "pcc.mcl.dummy.txt"
         source = "null"
-        soterm = 'polypeptide'
+        soterm = "polypeptide"
         test_coexpression_loader = FeatureLoader(source=source, filename=test_filename)
         test_coexpression_loader.store_feature_pairs(
             pair=test_pair1, soterm=soterm, term=term, value=test_pcc_value1
@@ -352,7 +352,7 @@ class CoexpressionTest(TestCase):
         test_filename = "mcl.clusters.dummy.txt"
         source = "null"
         test_coexpression_loader = FeatureLoader(source=source, filename=test_filename)
-        soterm = 'polypeptide'
+        soterm = "polypeptide"
         test_coexpression_loader.store_feature_groups(
             group=test_cluster1, soterm=soterm, term=term, value=test_cluster1_name
         )

--- a/machado/tests/test_loaders_coexpression.py
+++ b/machado/tests/test_loaders_coexpression.py
@@ -134,12 +134,13 @@ class CoexpressionTest(TestCase):
         # dummy coexpression variables
         test_filename = "pcc.mcl.dummy.txt"
         source = "null"
+        soterm = 'polypeptide'
         test_coexpression_loader = FeatureLoader(source=source, filename=test_filename)
         test_coexpression_loader.store_feature_pairs(
-            pair=test_pair1, term=term, value=test_pcc_value1
+            pair=test_pair1, soterm=soterm, term=term, value=test_pcc_value1
         )
         test_coexpression_loader.store_feature_pairs(
-            pair=test_pair2, term=term, value=test_pcc_value2
+            pair=test_pair2, soterm=soterm, term=term, value=test_pcc_value2
         )
         # start checking
         self.assertTrue(
@@ -351,14 +352,15 @@ class CoexpressionTest(TestCase):
         test_filename = "mcl.clusters.dummy.txt"
         source = "null"
         test_coexpression_loader = FeatureLoader(source=source, filename=test_filename)
+        soterm = 'polypeptide'
         test_coexpression_loader.store_feature_groups(
-            group=test_cluster1, term=term, value=test_cluster1_name
+            group=test_cluster1, soterm=soterm, term=term, value=test_cluster1_name
         )
         test_coexpression_loader.store_feature_groups(
-            group=test_cluster2, term=term, value=test_cluster2_name
+            group=test_cluster2, soterm=soterm, term=term, value=test_cluster2_name
         )
         test_coexpression_loader.store_feature_groups(
-            group=test_cluster3, term=term, value=test_cluster3_name
+            group=test_cluster3, soterm=soterm, term=term, value=test_cluster3_name
         )
         # check entire cluster1 relationships (not in reverse)
         self.assertTrue(

--- a/machado/tests/test_loaders_orthology.py
+++ b/machado/tests/test_loaders_orthology.py
@@ -470,7 +470,7 @@ class OrthologyTest(TestCase):
             common_name="multispecies",
         )
         source = "null"
-        soterm = 'polypeptide'
+        soterm = "polypeptide"
         test_orthology_loader = FeatureLoader(source=source, filename=filename)
         # ####################
         # test store groups

--- a/machado/tests/test_loaders_orthology.py
+++ b/machado/tests/test_loaders_orthology.py
@@ -470,6 +470,7 @@ class OrthologyTest(TestCase):
             common_name="multispecies",
         )
         source = "null"
+        soterm = 'polypeptide'
         test_orthology_loader = FeatureLoader(source=source, filename=filename)
         # ####################
         # test store groups
@@ -483,7 +484,7 @@ class OrthologyTest(TestCase):
             "UnknownProtein.v1.1",
         ]
         test_orthology_loader.store_feature_groups(
-            group=members1, term=term, value=group1_name
+            group=members1, soterm=soterm, term=term, value=group1_name
         )
         group2_name = "machado0002"
         members2 = [
@@ -493,7 +494,7 @@ class OrthologyTest(TestCase):
             "DCAR_031986.v1.0.388",
         ]
         test_orthology_loader.store_feature_groups(
-            group=members2, term=term, value=group2_name
+            group=members2, soterm=soterm, term=term, value=group2_name
         )
         group3_name = "machado0003"
         members3 = [
@@ -502,27 +503,27 @@ class OrthologyTest(TestCase):
             "DCAR_032182.v1.0.388",
         ]
         test_orthology_loader.store_feature_groups(
-            group=members3, term=term, value=group3_name
+            group=members3, soterm=soterm, term=term, value=group3_name
         )
         group4_name = "machado0004"
         members4 = ["Glyma.10G008400.1.Wm82.a2.v1", "", "UnknownProtein.v1.2"]
         test_orthology_loader.store_feature_groups(
-            group=members4, term=term, value=group4_name
+            group=members4, soterm=soterm, term=term, value=group4_name
         )
         group5_name = "machado0005"
         members5 = ["DCAR_000323.v1.0.388", "Kaladp0598s0002.1.v1.1"]
         test_orthology_loader.store_feature_groups(
-            group=members5, term=term, value=group5_name
+            group=members5, soterm=soterm, term=term, value=group5_name
         )
         group6_name = "machado0006"
         members6 = ["Kaladp0598s0001.1.v1.1", "UnknownProtein.v1.3"]
         test_orthology_loader.store_feature_groups(
-            group=members6, term=term, value=group6_name
+            group=members6, soterm=soterm, term=term, value=group6_name
         )
         group7_name = "machado0007"
         members7 = ["UnknownProtein.v1.4"]
         test_orthology_loader.store_feature_groups(
-            group=members7, term=term, value=group7_name
+            group=members7, soterm=soterm, term=term, value=group7_name
         )
 
         # ###check if relationships exist###


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
