### PR TITLE
remove the organism parameter

### DIFF
--- a/machado/loaders/sequence.py
+++ b/machado/loaders/sequence.py
@@ -125,7 +125,7 @@ class SequenceLoader(object):
         return None
 
     def add_sequence_to_feature(
-        self, seq_obj: SeqRecord, soterm: str, organism: str
+        self, seq_obj: SeqRecord, soterm: str
     ) -> None:
         """Store Biopython SeqRecord."""
         try:

--- a/machado/management/commands/load_feature_sequence.py
+++ b/machado/management/commands/load_feature_sequence.py
@@ -32,19 +32,12 @@ class Command(BaseCommand):
             required=True,
             type=str,
         )
-        parser.add_argument(
-            "--organism",
-            help="Species name (eg. Homo " "sapiens, Mus musculus)",
-            required=True,
-            type=str,
-        )
         parser.add_argument("--cpu", help="Number of threads", default=1, type=int)
 
     def handle(
         self,
         file: str,
         soterm: str,
-        organism: str,
         verbosity: int = 1,
         cpu: int = 1,
         **options
@@ -71,7 +64,7 @@ class Command(BaseCommand):
         for fasta in fasta_sequences:
             tasks.append(
                 pool.submit(
-                    sequence_file.add_sequence_to_feature, fasta, soterm, organism
+                    sequence_file.add_sequence_to_feature, fasta, soterm
                 )
             )
         if verbosity > 0:

--- a/machado/tests/test_loaders_sequence.py
+++ b/machado/tests/test_loaders_sequence.py
@@ -185,6 +185,6 @@ class SequenceTest(TestCase):
         test_seq_obj = SeqRecord(
             Seq("aaaaaaaaaaaaaaaaaaaa"), id="chr1", description="chromosome 1"
         )
-        test_seq_file.add_sequence_to_feature(test_seq_obj, "assembly", "Mus musculus")
+        test_seq_file.add_sequence_to_feature(test_seq_obj, "assembly")
         test_feature_seq = Feature.objects.get(uniquename="chr1")
         self.assertEqual("aaaaaaaaaaaaaaaaaaaa", test_feature_seq.residues)


### PR DESCRIPTION
the function retrieve_feature_id doesn't require the organism info.


I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
