### PR TITLE
load_coexpression_pairs minor correction

### DIFF
--- a/machado/management/commands/load_coexpression_pairs.py
+++ b/machado/management/commands/load_coexpression_pairs.py
@@ -43,6 +43,7 @@ The feature pairs from columns 1 and 2 need to be loaded previously."""
             "--soterm",
             help="sequence ontology term 'e.g. mRNA'",
             required=False,
+            default='mRNA',
             type=str,
         )
         parser.add_argument("--cpu", help="Number of threads", default=1, type=int)


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
