### PR TITLE
update travis to run tests on trusty (python 3.6) and xenial (python 3.6 and 3.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 cache: pip
-
 matrix:
   include:
     - dist: trusty
+      language: python
       python: "3.6"
-  - dist: xenial
+    - dist: xenial
       python: "3.6"
-  - dist: xenial
+    - dist: xenial
       python: "3.7"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-dist: trusty
-language: python
 matrix:
   include:
-  - python: "3.6"
-    cache: pip
-  - python: "3.7"
-    cache: pip
+    - dist: trusty
+      python: "3.6"
+    - dist: xenial
+      python: "3.6"
+    - dist: xenial
+      python: "3.7"
+
+cache: pip
 
 before_install:
   - psql -c "create user username with encrypted password 'password';" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
+language: python
+cache: pip
+
 matrix:
   include:
     - dist: trusty
+      language: python
       python: "3.6"
     - dist: xenial
       python: "3.6"
     - dist: xenial
       python: "3.7"
-
-cache: pip
 
 before_install:
   - psql -c "create user username with encrypted password 'password';" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-language: python
 cache: pip
 matrix:
   include:
@@ -6,8 +5,10 @@ matrix:
       language: python
       python: "3.6"
     - dist: xenial
+      language: python
       python: "3.6"
     - dist: xenial
+      language: python
       python: "3.7"
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,13 @@ matrix:
     - dist: trusty
       language: python
       python: "3.6"
+      env TEST_SUIT=trusty_python3.6
     - dist: xenial
       python: "3.6"
+      env TEST_SUIT=xenial_python3.6
     - dist: xenial
       python: "3.7"
-    - dist: bionic
-      python: "3.6"
-    - dist: bionic
-      python: "3.7"
+      env TEST_SUIT=xenial_python3.7
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 dist: trusty
 language: python
-python:
-  - "3.6"
-cache: pip
+matrix:
+  include:
+  - python: "3.6"
+    cache: pip
+  - python: "3.7"
+    cache: pip
 
 before_install:
   - psql -c "create user username with encrypted password 'password';" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ cache: pip
 matrix:
   include:
     - dist: trusty
-      language: python
       python: "3.6"
       env TEST_SUIT=trusty_python3.6
-    - dist: xenial
-      python: "3.6"
-      env TEST_SUIT=xenial_python3.6
     - dist: xenial
       python: "3.7"
       env TEST_SUIT=xenial_python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ matrix:
   include:
     - dist: trusty
       python: "3.6"
-      env TEST_SUIT=trusty_python3.6
-    - dist: xenial
+      env: TEST_SUITE=trusty_python3.6
+  - dist: xenial
+      python: "3.6"
+      env: TEST_SUITE=xenial_python3.6
+  - dist: xenial
       python: "3.7"
-      env TEST_SUIT=xenial_python3.7
+      env: TEST_SUITE=xenial_python3.7
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,10 @@ matrix:
   include:
     - dist: trusty
       python: "3.6"
-      env: TEST_SUITE=trusty_python3.6
   - dist: xenial
       python: "3.6"
-      env: TEST_SUITE=xenial_python3.6
   - dist: xenial
       python: "3.7"
-      env: TEST_SUITE=xenial_python3.7
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ matrix:
       python: "3.6"
     - dist: xenial
       python: "3.7"
+    - dist: bionic
+      python: "3.6"
+    - dist: bionic
+      python: "3.7"
+
+services:
+  - postgresql
 
 before_install:
   - psql -c "create user username with encrypted password 'password';" -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 cache: pip
+language: python
 matrix:
   include:
     - dist: trusty
-      language: python
       python: "3.6"
     - dist: xenial
-      language: python
       python: "3.6"
     - dist: xenial
-      language: python
       python: "3.7"
 
 services:


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
