### PR TITLE
adds the organism multispecies

### DIFF
--- a/machado/migrations/0003_add_multispecies.py
+++ b/machado/migrations/0003_add_multispecies.py
@@ -1,0 +1,17 @@
+# Copyright 2018 by Embrapa.  All rights reserved.
+#
+# This code is part of the machado distribution and governed by its
+# license. Please see the LICENSE.txt and README.md files that should
+# have been included as part of this package for licensing information.
+
+"""Create database from chado default_schema.sql."""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Migration."""
+    dependencies = [('machado','0001_initial'), ('machado', '0002_add_index')]
+
+    operations = [
+        migrations.RunSQL('insert into organism (abbreviation, genus, species, common_name) values (\'multispecies\', \'multispecies\', \'multispecies\', \'multispecies\')'),
+    ]


### PR DESCRIPTION
This pull request addresses issue #236 

By registering the organism 'multispecies' during the initial database setup (migrate) will ensure the command will not create duplicate entries when using multiple threads


I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
