### PR TITLE
fix remove_analysis to raise error if the file is not registered

### DIFF
--- a/machado/management/commands/remove_analysis.py
+++ b/machado/management/commands/remove_analysis.py
@@ -39,13 +39,14 @@ class Command(BaseCommand):
                 "Deleting {} and every child" "record (CASCADE)".format(name)
             )
 
-        try:
-            cvterm_contained_in = Cvterm.objects.get(
-                name="contained in", cv__name="relationship"
-            )
-            analysisprop_list = Analysisprop.objects.filter(
-                value=name, type_id=cvterm_contained_in.cvterm_id
-            )
+        cvterm_contained_in = Cvterm.objects.get(
+            name="contained in", cv__name="relationship"
+        )
+        analysisprop_list = Analysisprop.objects.filter(
+            value=name, type_id=cvterm_contained_in.cvterm_id
+        )
+
+        if analysisprop_list.count() > 0:
 
             for analysisprop in tqdm(
                 analysisprop_list,
@@ -98,5 +99,5 @@ class Command(BaseCommand):
                 analysis.delete()
             if verbosity > 0:
                 self.stdout.write(self.style.SUCCESS("Done"))
-        except ObjectDoesNotExist:
+        else:
             raise CommandError("Cannot remove {} (not registered)".format(name))

--- a/machado/tests/test_loaders_analysis.py
+++ b/machado/tests/test_loaders_analysis.py
@@ -32,7 +32,7 @@ class AnalysisTest(TestCase):
     def test_store_analysis(self):
         """Run Tests ."""
         # register multispecies organism
-        test_organism = Organism.objects.create(
+        test_organism, created = Organism.objects.get_or_create(
             abbreviation="multispecies",
             genus="multispecies",
             species="multispecies",

--- a/machado/tests/test_loaders_coexpression.py
+++ b/machado/tests/test_loaders_coexpression.py
@@ -31,7 +31,7 @@ class CoexpressionTest(TestCase):
     subtracted from 0.7 (PCC - 0.7). To obtain the original PCC value,
     it must be added 0.7 to every value of the third column."""
         # register multispecies organism
-        test_organism = Organism.objects.create(
+        test_organism, created = Organism.objects.get_or_create(
             abbreviation="multispecies",
             genus="multispecies",
             species="multispecies",

--- a/machado/tests/test_loaders_similarity.py
+++ b/machado/tests/test_loaders_similarity.py
@@ -43,7 +43,7 @@ class SimilarityTest(TestCase):
         )
 
         test_organism = Organism.objects.create(genus="Mus", species="musculus")
-        test_organism2 = Organism.objects.create(
+        test_organism2, created = Organism.objects.get_or_create(
             abbreviation="multispecies",
             genus="multispecies",
             species="multispecies",

--- a/machado/tests/test_views_common.py
+++ b/machado/tests/test_views_common.py
@@ -292,7 +292,7 @@ class CongratsTest(TestCase):
             'Controlled Vocabularies <span class="badge badge-primary badge-pill">1</span>',
         )
         self.assertContains(
-            response, 'Organisms <span class="badge badge-primary badge-pill">1</span>'
+            response, 'Organisms <span class="badge badge-primary badge-pill">2</span>'
         )
         self.assertContains(
             response, 'Features <span class="badge badge-primary badge-pill">1</span>'

--- a/machado/tests/test_views_feature.py
+++ b/machado/tests/test_views_feature.py
@@ -158,7 +158,7 @@ class FeatureTest(TestCase):
         )
 
         self.organism1 = Organism.objects.create(genus="Mus", species="musculus")
-        multispecies_organism = Organism.objects.create(
+        multispecies_organism, created = Organism.objects.get_or_create(
             genus="multispecies", species="multispecies"
         )
 


### PR DESCRIPTION
This pull request addresses issue #237 

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
