### PR TITLE
show download buttons when orthologous_group or coexpression_group is…

### DIFF
--- a/machado/templates/search_result.html
+++ b/machado/templates/search_result.html
@@ -23,7 +23,7 @@
                     <h3>Results</h3>
                 </div>
                 <div class="col text-right">
-                    {% if so_term_count == 1 %}
+                    {% if so_term_count == 1 or 'orthologous_group' in selected_facets_fields or 'coexpression_group' in selected_facets_fields %}
                         <a class="fas fa-download" href="{% url 'feature_search_export' %}?{{ request.GET.urlencode }}&export=tsv" title="Download TSV" onclick="return confirm('Download results in TSV format')"></a>
                         <a class="fas fa-download" href="{% url 'feature_search_export' %}?{{ request.GET.urlencode }}&export=fasta" title="Download FASTA" onclick="return confirm('Download results in FASTA format')"></a>
                     {% endif %}

--- a/machado/views/search.py
+++ b/machado/views/search.py
@@ -50,9 +50,8 @@ class FeatureSearchView(FacetedSearchView):
             facet_field, facet_query = facet.split(":")
             if facet_field == 'so_term':
                 so_term_count += 1
-            if facet_field not in ["orthologous_group", "coexpression_group"]:
-                selected_facets_fields.append(facet_field)
-                selected_facets.append(facet)
+            selected_facets_fields.append(facet_field)
+            selected_facets.append(facet)
 
         context["so_term_count"] = so_term_count
 


### PR DESCRIPTION
This pull request addresses issue #242 

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
