### PR TITLE
updates the download .fasta and .tsv buttons

### DIFF
--- a/machado/templates/search_result.out
+++ b/machado/templates/search_result.out
@@ -1,7 +1,7 @@
 {% if file_format == 'tsv' %}SO term	Feature ID	Display	Group
-{% for result in object_list %}{{ result.object.type.name }}	{{ result.uniquename }}	{{ result.object.get_display|default_if_none:'' }}	{% if result.object.type.name == 'polypeptide' %}{{ result.object.get_orthologous_group|default_if_none:'' }}{% elif result.object.type.name == 'mRNA' %}{{ result.object.get_coexpression_group|default_if_none:'' }}{% endif %}
+{% for result in object_list %}{{ result.so_term }}	{{ result.uniquename }}	{{ result.display|default_if_none:'' }}	{% if result.so_term == 'polypeptide' %}{{ result.orthologous_group|default_if_none:'' }}{% elif result.so_term == 'mRNA' %}{{ result.coexpression_group|default_if_none:'' }}{% endif %}
 {% endfor %}
-{% elif file_format == 'fasta' %}{% for result in object_list %}{% if result.object.residues %}>{{ result.object.dbxref.accession }} {{ result.object.get_display|default_if_none:'' }}
+{% elif file_format == 'fasta' %}{% for result in object_list %}{% if result.object.residues %}>{{ result.object.dbxref.accession }} {{ result.display|default_if_none:'' }}
 {{ result.object.residues }}
 {% endif %}{% endfor %}
 {% else %}Unknown format.{% endif %}


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
