### PR TITLE
fixes get_num_lines to handle both str and bytes

### DIFF
--- a/machado/loaders/common.py
+++ b/machado/loaders/common.py
@@ -84,7 +84,9 @@ def get_num_lines(file_path):
 
     i = 0
     for line in fp:
-        if str(line).startswith("#") or line.startswith(b'#'):
+        if type(line) == str and str(line).startswith("#"):
+            continue
+        if type(line) == bytes and line.startswith(b'#'):
             continue
         i += 1
     return i


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
