### PR TITLE
added retrieve_feature_id to store_feature_groups and corrected bug in remove_feature_annotation when organism is Null

### DIFF
--- a/machado/management/commands/remove_feature_annotation.py
+++ b/machado/management/commands/remove_feature_annotation.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
             feature_props = Featureprop.objects.filter(
                 type=cvterm_obj, feature__organism=organism_obj
             )
-        except ObjectDoesNotExist:
+        except (ObjectDoesNotExist, AttributeError):
             feature_props = Featureprop.objects.filter(type=cvterm_obj)
 
         count = feature_props.count()


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
