### PR TITLE
Fixes: postgres error log

### DIFF
--- a/machado/migrations/0001_initial.py
+++ b/machado/migrations/0001_initial.py
@@ -15,7 +15,11 @@ def load_data_from_sql(apps, schema_editor):
     file_path = os.path.join(
         os.path.dirname(__file__), "../schemas/1.31/default_schema.sql"
     )
-    sql_statement = open(file_path).read()
+    sql_statement = ""
+    for line in open(file_path).readlines():
+        line = line.replace("(create_point", "(public.create_point")
+        line = line.replace(", create_point", ", public.create_point")
+        sql_statement += line
     with connection.cursor() as c:
         c.execute(sql_statement)
 


### PR DESCRIPTION
ERROR:  function create_point(integer, bigint) does not exist at character 13
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
2020-07-25 00:36:31.707 UTC [86] QUERY:  SELECT box (create_point(0, $1), create_point($2,500000000))
CONTEXT:  SQL function "boxrange" during inlining
automatic analyze of table "machadosample.public.featureloc"
