### PR TITLE
adds accession to jbrowse tracks and includes feature.name, feature.uniquename, and overlapping_features.uniquename to the text search

### DIFF
--- a/extras/trackList.json.sample
+++ b/extras/trackList.json.sample
@@ -24,6 +24,7 @@
          "key" : "Gene",
          "label" : "gene",
          "query" : {
+            "organism": "Arabidopsis thaliana",
             "soType" : "gene"
          },
          "storeClass" : "JBrowse/Store/SeqFeature/REST",
@@ -39,6 +40,7 @@
          "key" : "Transcript",
          "label" : "transcripts",
          "query" : {
+            "organism": "Arabidopsis thaliana",
             "soType" : "mRNA"
          },
          "storeClass" : "JBrowse/Store/SeqFeature/REST",
@@ -54,11 +56,23 @@
          "key" : "CDS",
          "label" : "CDS",
          "query" : {
+            "organism": "Arabidopsis thaliana",
             "soType" : "CDS"
          },
          "storeClass" : "JBrowse/Store/SeqFeature/REST",
          "type" : "JBrowse/View/Track/CanvasFeatures"
+     },
+      {
+         "category": "3. Variation",
+         "baseUrl" : "http://localhost:8000/machado/api/jbrowse",
+         "key" : "SNV",
+         "label" : "SNV",
+         "query" : {
+            "organism" : "Arabidopsis thaliana",
+            "soType" : "SNV"
+         },
+         "storeClass" : "JBrowse/Store/SeqFeature/REST",
+         "type" : "JBrowse/View/Track/HTMLFeatures"
      }
-
    ]
 }

--- a/machado/api/serializers.py
+++ b/machado/api/serializers.py
@@ -60,6 +60,7 @@ class JBrowseFeatureSerializer(serializers.ModelSerializer):
     end = serializers.SerializerMethodField()
     strand = serializers.SerializerMethodField()
     type = serializers.SerializerMethodField()
+    accession = serializers.SerializerMethodField()
     uniqueID = serializers.SerializerMethodField()
     subfeatures = serializers.SerializerMethodField()
     seq = serializers.SerializerMethodField()
@@ -71,6 +72,7 @@ class JBrowseFeatureSerializer(serializers.ModelSerializer):
         model = Feature
         fields = (
             "uniqueID",
+            "accession",
             "name",
             "type",
             "start",
@@ -131,6 +133,10 @@ class JBrowseFeatureSerializer(serializers.ModelSerializer):
         """Get the type."""
         feat_type = obj.type.name
         return feat_type
+
+    def get_accession(self, obj):
+        """Get the uniquename."""
+        return obj.uniquename
 
     def get_uniqueID(self, obj):
         """Get the uniquename."""

--- a/machado/search_indexes.py
+++ b/machado/search_indexes.py
@@ -131,7 +131,7 @@ class FeatureIndex(indexes.SearchIndex, indexes.Indexable):
         for location in obj.Featureloc_feature_Feature.all():
             for overlapping_feature in Featureloc.objects.filter(
                 srcfeature=location.srcfeature,
-                feature__type__name='SNV',
+                feature__type__name="SNV",
                 fmin__lte=location.fmax,
                 fmax__gte=location.fmin,
             ):

--- a/machado/search_indexes.py
+++ b/machado/search_indexes.py
@@ -127,6 +127,20 @@ class FeatureIndex(indexes.SearchIndex, indexes.Indexable):
             for i in sample.get("treatment_name").split(" "):
                 keywords.add(i)
 
+        # IDs of overlapping features
+        for location in obj.Featureloc_feature_Feature.all():
+            for overlapping_feature in Featureloc.objects.filter(
+                srcfeature=location.srcfeature,
+                feature__type__name='SNV',
+                fmin__lte=location.fmax,
+                fmax__gte=location.fmin,
+            ):
+                keywords.add(overlapping_feature.feature.uniquename)
+
+        if obj.name is not None:
+            keywords.add(obj.name)
+        keywords.add(obj.uniquename)
+
         self.temp = " ".join(keywords)
         return " ".join(keywords)
 

--- a/machado/templates/feature.html
+++ b/machado/templates/feature.html
@@ -20,7 +20,7 @@
     <div class="card-header">
         <small><i>{{ feature.organism.genus }} {{ feature.organism.species }}</i></small>
         <h3 class="card-title">
-			{{ feature.type.name }}: {{ feature.name }}
+			{{ feature.type.name }}: {{ feature.name|default_if_none:feature.uniquename }}
 		</h3>
     </div>
     <div class="card-body">


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
