### PR TITLE
assay.py implemented get_or_create for assay_prop

### DIFF
--- a/machado/loaders/assay.py
+++ b/machado/loaders/assay.py
@@ -127,7 +127,7 @@ class AssayLoader(object):
     ) -> None:
         """Store analysisprop."""
         try:
-            Assayprop.objects.create(
+            Assayprop.objects.get_or_create(
                 assay=assay, type_id=type_id, value=value, rank=rank
             )
         except IntegrityError as e:


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
