### PR TITLE
Indexing improvement

### DIFF
--- a/machado/search_indexes.py
+++ b/machado/search_indexes.py
@@ -51,6 +51,7 @@ class FeatureIndex(indexes.SearchIndex, indexes.Indexable):
     orthologs_coexpression = indexes.MultiValueField(faceted=True)
 
     def __init__(self):
+        """Check for overlapping features."""
         self.has_overlapping_features = Feature.objects.filter(type__name__in=OVERLAPPING_FEATURES).exists()
         super()
 

--- a/machado/search_indexes.py
+++ b/machado/search_indexes.py
@@ -52,7 +52,9 @@ class FeatureIndex(indexes.SearchIndex, indexes.Indexable):
 
     def __init__(self):
         """Check for overlapping features."""
-        self.has_overlapping_features = Feature.objects.filter(type__name__in=OVERLAPPING_FEATURES).exists()
+        self.has_overlapping_features = Feature.objects.filter(
+            type__name__in=OVERLAPPING_FEATURES
+        ).exists()
         super()
 
     def get_model(self):

--- a/machado/search_indexes.py
+++ b/machado/search_indexes.py
@@ -50,6 +50,10 @@ class FeatureIndex(indexes.SearchIndex, indexes.Indexable):
     # orthologs_biomaterial = indexes.MultiValueField(faceted=True)
     orthologs_coexpression = indexes.MultiValueField(faceted=True)
 
+    def __init__(self):
+        self.has_overlapping_features = Feature.objects.filter(type__name__in=OVERLAPPING_FEATURES).exists()
+        super()
+
     def get_model(self):
         """Get model."""
         return Feature
@@ -134,7 +138,7 @@ class FeatureIndex(indexes.SearchIndex, indexes.Indexable):
                 keywords.add(i)
 
         # IDs of overlapping features
-        if Feature.objects.filter(type__name__in=OVERLAPPING_FEATURES).exists():
+        if self.has_overlapping_features:
 
             try:
                 for location in obj.Featureloc_feature_Feature.filter(


### PR DESCRIPTION
While building the search index, the database was using 100% CPU running this query repeatedly:

```
SELECT 
(1) AS "a" FROM "feature" INNER JOIN "cvterm" ON ("feature"."type_id" = "cvterm"."cvterm_id") WHERE "cvterm"."name" IN ('SNV', 'QTL') LIMIT 1 
```

This value shouldn't change while building the search index.

This PR changes it to run only once.

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.
