### PR TITLE
Call init properly

### DIFF
--- a/machado/search_indexes.py
+++ b/machado/search_indexes.py
@@ -55,6 +55,7 @@ class FeatureIndex(indexes.SearchIndex, indexes.Indexable):
         self.has_overlapping_features = Feature.objects.filter(
             type__name__in=OVERLAPPING_FEATURES
         ).exists()
+        super().__init__()
 
     def get_model(self):
         """Get model."""


### PR DESCRIPTION
In yesterday's pull request I overrode the init method of the search index class and did it wrong.

It looks like SearchIndex.__init__ does some stuff and should still be called, although it seemed to work without doing so yeaterday.

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.
