### PR TITLE
updates the Django version and changes the operator to ~= in order to allow compatible versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     scripts=["bin/fixChadoModel.py"],
     install_requires=[
         "numpy>=1.19",
-        "django==3.1.12",
+        "django~=3.1.13",
         "psycopg2-binary==2.8.6",
         "obonet==0.3.0",
         "biopython==1.79",


### PR DESCRIPTION


This pull request addresses issue #321 

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
