### PR TITLE
Handle weird xrefs during loading

### DIFF
--- a/machado/loaders/feature.py
+++ b/machado/loaders/feature.py
@@ -425,7 +425,7 @@ class FeatureLoader(object):
         )
 
         for aux_dbxref in searchio_hit.dbxrefs:
-            aux_db, aux_term = aux_dbxref.split(":")
+            aux_db, aux_term = aux_dbxref.split(":", 1)
             if aux_db == "GO":
                 try:
                     term_db = Db.objects.get(name=aux_db.upper())
@@ -469,7 +469,7 @@ class FeatureLoader(object):
         feature_id = retrieve_feature_id(accession=feature, soterm=soterm)
 
         try:
-            db_name, dbxref_accession = dbxref.split(":")
+            db_name, dbxref_accession = dbxref.split(":", 1)
         except ValueError:
             raise ImportingError(
                 "Incorrect DBxRef {}. It should have two colon-separated values (eg. DB:DBxREF).".format(

--- a/machado/loaders/featureattributes.py
+++ b/machado/loaders/featureattributes.py
@@ -140,7 +140,7 @@ class FeatureAttributesLoader(object):
                 terms = attrs[key].split(",")
                 for term in terms:
                     try:
-                        aux_db, aux_term = term.split(":")
+                        aux_db, aux_term = term.split(":", 1)
                         term_db = Db.objects.get(name=aux_db.upper())
                         dbxref = Dbxref.objects.get(db=term_db, accession=aux_term)
                         cvterm = Cvterm.objects.get(dbxref=dbxref)
@@ -161,7 +161,7 @@ class FeatureAttributesLoader(object):
                 for dbxref in dbxrefs:
                     # It expects just one dbxref formated as XX:012345
                     try:
-                        aux_db, aux_dbxref = dbxref.split(":")
+                        aux_db, aux_dbxref = dbxref.split(":", 1)
                     except ValueError as e:
                         raise ImportingError("{}: {}".format(dbxref, e))
                     db, created = Db.objects.get_or_create(name=aux_db.upper())


### PR DESCRIPTION
The importer initially ran into an issue trying to import xrefs on some features

https://db.scnbase.org/feature/?feature_id=215199

specifically these: `GENE3D:G3DSA:1.10.287.770`

This resolved it.

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
