### PR TITLE
Upgrade django to 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     scripts=["bin/fixChadoModel.py"],
     install_requires=[
         "numpy>=1.19",
-        "django~=3.2.6",
+        "django~=3.2.7",
         "psycopg2-binary==2.8.6",
         "obonet==0.3.0",
         "biopython==1.79",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     scripts=["bin/fixChadoModel.py"],
     install_requires=[
         "numpy>=1.19",
-        "django~=3.1.13",
+        "django~=3.2.6",
         "psycopg2-binary==2.8.6",
         "obonet==0.3.0",
         "biopython==1.79",


### PR DESCRIPTION
I've been running with django 3.2 for about a month now and haven't noticed any issues.

Django 3.2 is designated as a long-term support release. It will receive security updates for at least three years after April 6, 2021. 

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
