### PR TITLE
creates correspondent protein record for C_gene_segment and V_gene_segment sequence types

### DIFF
--- a/machado/loaders/feature.py
+++ b/machado/loaders/feature.py
@@ -231,7 +231,8 @@ class FeatureLoader(FeatureLoaderBase):
             self.relationships.append({"object_id": attrs_id, "subject_id": parent})
 
         # Additional protein record for each transcript with the exact same ID
-        if tabix_feature.feature in list("mRNA", "C_gene_segment", "V_gene_segment"):
+        transcripts_types = ["mRNA", "C_gene_segment", "V_gene_segment"]
+        if tabix_feature.feature in transcripts_types:
             translation_of = Cvterm.objects.get(
                 name="translation_of", cv__name="sequence"
             )

--- a/machado/loaders/feature.py
+++ b/machado/loaders/feature.py
@@ -230,8 +230,8 @@ class FeatureLoader(FeatureLoaderBase):
         for parent in attrs_parent:
             self.relationships.append({"object_id": attrs_id, "subject_id": parent})
 
-        # Additional protrein record for each mRNA with the exact same ID
-        if tabix_feature.feature == "mRNA":
+        # Additional protein record for each transcript with the exact same ID
+        if tabix_feature.feature in list("mRNA", "C_gene_segment", "V_gene_segment"):
             translation_of = Cvterm.objects.get(
                 name="translation_of", cv__name="sequence"
             )


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
