### PR TITLE
enable searches using wildcards (*) or substrings

### DIFF
--- a/machado/forms.py
+++ b/machado/forms.py
@@ -7,7 +7,9 @@
 
 from django import forms
 from django.contrib.postgres.search import SearchQuery, SearchRank
-from django.db.models import Q
+from django.db.models import Q, Value
+from django.db.models.functions import Cast
+from django.db import models
 
 from machado.models import FeatureSearchIndex
 
@@ -40,10 +42,32 @@ class FeatureSearchForm(forms.Form):
 
         # ── Apply full-text query ────────────────────────────────────────
         if q:
-            query = SearchQuery(q, config="english", search_type="websearch")
-            qs = qs.filter(search_vector=query).annotate(
+            # Save the faceted queryset to use in fallback if FTS fails
+            base_qs = qs
+
+            if "*" in q:
+                # Handle wildcard search: "abc*" -> "abc:*"
+                terms = [f"{t[:-1]}:*" if t.endswith("*") else t for t in q.split()]
+                query = SearchQuery(" & ".join(terms), config="english", search_type="raw")
+            else:
+                # Standard websearch (supports quotes, +, -)
+                query = SearchQuery(q, config="english", search_type="websearch")
+
+            qs = base_qs.filter(search_vector=query).annotate(
                 rank=SearchRank("search_vector", query)
             )
+
+            # Substring fallback: if no FTS results, try partial matching on key fields
+            if not qs.exists():
+                clean_q = q.replace("*", "")
+                qs = (
+                    base_qs.filter(
+                        Q(uniquename__icontains=clean_q)
+                        | Q(name__icontains=clean_q)
+                        | Q(display__icontains=clean_q)
+                    )
+                    .annotate(rank=Value(0.0, output_field=models.FloatField()))
+                )
 
         return qs
 

--- a/machado/forms.py
+++ b/machado/forms.py
@@ -8,7 +8,6 @@
 from django import forms
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import Q, Value
-from django.db.models.functions import Cast
 from django.db import models
 
 from machado.models import FeatureSearchIndex
@@ -48,7 +47,9 @@ class FeatureSearchForm(forms.Form):
             if "*" in q:
                 # Handle wildcard search: "abc*" -> "abc:*"
                 terms = [f"{t[:-1]}:*" if t.endswith("*") else t for t in q.split()]
-                query = SearchQuery(" & ".join(terms), config="english", search_type="raw")
+                query = SearchQuery(
+                    " & ".join(terms), config="english", search_type="raw"
+                )
             else:
                 # Standard websearch (supports quotes, +, -)
                 query = SearchQuery(q, config="english", search_type="websearch")
@@ -60,14 +61,11 @@ class FeatureSearchForm(forms.Form):
             # Substring fallback: if no FTS results, try partial matching on key fields
             if not qs.exists():
                 clean_q = q.replace("*", "")
-                qs = (
-                    base_qs.filter(
-                        Q(uniquename__icontains=clean_q)
-                        | Q(name__icontains=clean_q)
-                        | Q(display__icontains=clean_q)
-                    )
-                    .annotate(rank=Value(0.0, output_field=models.FloatField()))
-                )
+                qs = base_qs.filter(
+                    Q(uniquename__icontains=clean_q)
+                    | Q(name__icontains=clean_q)
+                    | Q(display__icontains=clean_q)
+                ).annotate(rank=Value(0.0, output_field=models.FloatField()))
 
         return qs
 

--- a/machado/tests/test_forms.py
+++ b/machado/tests/test_forms.py
@@ -61,10 +61,12 @@ class FeatureSearchFormTest(TestCase):
         ) as mock_select:
             mock_qs = MagicMock()
             mock_select.return_value.all.return_value = mock_qs
-            mock_qs.filter.return_value.annotate.return_value = "annotated_qs"
+            mock_annotated = MagicMock()
+            mock_annotated.exists.return_value = True
+            mock_qs.filter.return_value.annotate.return_value = mock_annotated
 
             result = form.search()
-            self.assertEqual(result, "annotated_qs")
+            self.assertEqual(result, mock_annotated)
 
             # verify it filters by search_vector
             filter_kwargs = mock_qs.filter.call_args[1]
@@ -90,10 +92,84 @@ class FeatureSearchFormTest(TestCase):
 
             # Mocks for facet chaining
             mock_qs.filter.return_value = mock_qs
-            mock_qs.annotate.return_value = "final_qs"
+            mock_annotated = MagicMock()
+            mock_annotated.exists.return_value = True
+            mock_qs.annotate.return_value = mock_annotated
 
             result = form.search(selected_facets=selected_facets)
-            self.assertEqual(result, "final_qs")
+            self.assertEqual(result, mock_annotated)
 
             # sqs.filter should have been called multiple times
             self.assertTrue(mock_qs.filter.called)
+
+    def test_search_with_wildcard(self):
+        """Test wildcard search with '*'."""
+        data = QueryDict(mutable=True)
+        data.update({"q": "test*"})
+        form = FeatureSearchForm(data=data)
+        form.is_valid = MagicMock(return_value=True)
+        form.cleaned_data = {"q": "test*"}
+
+        with patch(
+            "machado.forms.FeatureSearchIndex.objects.select_related"
+        ) as mock_select:
+            mock_qs = MagicMock()
+            mock_select.return_value.all.return_value = mock_qs
+            # Mock .exists() to avoid fallback during this test
+            mock_qs.filter.return_value.annotate.return_value.exists.return_value = True
+
+            form.search()
+
+            # Verify SearchQuery uses raw search (to_tsquery) and contains ':*'
+            query = mock_qs.filter.call_args[1]["search_vector"]
+            # Django's SearchQuery stores the function ('to_tsquery' for raw)
+            self.assertEqual(query.function, "to_tsquery")
+            # The query value is usually the second source expression
+            self.assertIn("test:*", str(query.source_expressions[1]))
+
+    def test_search_substring_fallback(self):
+        """Test fallback to icontains if FTS yields no results."""
+        data = QueryDict(mutable=True)
+        data.update({"q": "ATMG"})
+        form = FeatureSearchForm(data=data)
+        form.is_valid = MagicMock(return_value=True)
+        form.cleaned_data = {"q": "ATMG"}
+
+        with patch(
+            "machado.forms.FeatureSearchIndex.objects.select_related"
+        ) as mock_select:
+            mock_qs = MagicMock()
+            mock_select.return_value.all.return_value = mock_qs
+
+            # Mock FTS results and fallback results
+            fts_results = MagicMock()
+            fts_results.exists.return_value = False  # Trigger fallback
+
+            substring_results = MagicMock()
+            substring_results.exists.return_value = True
+
+            # mock_qs.filter.return_value is what .annotate is called on
+            annotatable_qs = mock_qs.filter.return_value
+            annotatable_qs.annotate.side_effect = [fts_results, substring_results]
+
+            form.search()
+
+            # The second filter call should be the fallback substring search
+            self.assertEqual(mock_qs.filter.call_count, 2)
+
+            # Verify that annotate was called twice on the filtered queryset
+            self.assertEqual(annotatable_qs.annotate.call_count, 2)
+
+            # Check the second call to annotate (the fallback one)
+            fallback_annotate_args = annotatable_qs.annotate.call_args_list[1]
+            rank_arg = fallback_annotate_args[1]["rank"]
+            from django.db.models import Value
+
+            self.assertIsInstance(rank_arg, Value)
+            self.assertEqual(rank_arg.value, 0.0)
+
+            # Verify the fallback filter had Q objects or icontains
+            fallback_filter_args = mock_qs.filter.call_args_list[1]
+            self.assertTrue(
+                any("icontains" in str(arg) for arg in fallback_filter_args[0])
+            )


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
