### PR TITLE
fix the Load Fasta form to handle the parameter nosequence properly

### DIFF
--- a/machado/tests/test_views_loader.py
+++ b/machado/tests/test_views_loader.py
@@ -4,10 +4,11 @@
 # license. Please see the LICENSE.txt and README.md files that should
 # have been included as part of this package for licensing information.
 
+import tempfile
 from unittest.mock import patch, MagicMock
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase, Client
+from django.test import TestCase, Client, override_settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 from machado.models import Db, Dbxref
@@ -72,6 +73,7 @@ class LoaderViewsTest(TestCase):
             return MagicMock()
 
         with (
+            override_settings(BASE_DIR=tempfile.gettempdir()),
             patch("machado.views.loader.threading.Thread", side_effect=run_target_now),
             patch("machado.views.loader.subprocess.Popen") as mock_popen,
         ):

--- a/machado/tests/test_views_loader.py
+++ b/machado/tests/test_views_loader.py
@@ -4,6 +4,9 @@
 # license. Please see the LICENSE.txt and README.md files that should
 # have been included as part of this package for licensing information.
 
+from unittest.mock import patch, MagicMock
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -51,3 +54,35 @@ class LoaderViewsTest(TestCase):
         self.assertContains(
             response, '<option value="interproscan-xml">interproscan-xml</option>'
         )
+
+    def test_load_fasta_checkbox_nosequence_sent_as_flag(self):
+        """Regression: a checked 'nosequence' checkbox must become a bare
+        --nosequence flag, not '--nosequence true', which argparse rejects
+        for a store_true argument."""
+        url = reverse("loader_command_form", kwargs={"command_name": "load_fasta"})
+        data = {
+            "file_upload": SimpleUploadedFile("test.fasta", b">seq1\nACGT\n"),
+            "organism": "999999",
+            "soterm": "999999",
+            "nosequence": "true",
+        }
+
+        def run_target_now(target=None, **kwargs):
+            target()
+            return MagicMock()
+
+        with (
+            patch("machado.views.loader.threading.Thread", side_effect=run_target_now),
+            patch("machado.views.loader.subprocess.Popen") as mock_popen,
+        ):
+            mock_popen.return_value.pid = 1234
+            mock_popen.return_value.returncode = 0
+            mock_popen.return_value.communicate.return_value = ("", "")
+
+            self.client.post(url, data)
+
+        cmd = mock_popen.call_args[0][0]
+        self.assertIn("--nosequence", cmd)
+        idx = cmd.index("--nosequence")
+        next_token = cmd[idx + 1] if idx + 1 < len(cmd) else None
+        self.assertNotEqual(next_token, "true")

--- a/machado/views/loader.py
+++ b/machado/views/loader.py
@@ -1258,7 +1258,9 @@ class CommandFormView(LoginRequiredMixin, View):
                             "loader_command_form", command_name=command_name
                         )
 
-                    if val:
+                    if arg["type"] == "checkbox":
+                        val = True if val else False
+                    elif val:
                         val = val.strip()
                         if arg["type"] == "organism":
                             try:
@@ -1277,8 +1279,6 @@ class CommandFormView(LoginRequiredMixin, View):
                             val = cv.name
                         except Cv.DoesNotExist:
                             pass
-                    elif arg["type"] == "checkbox":
-                        val = True if val else False
                     elif arg["type"] == "soterm":
                         try:
                             term = Cvterm.objects.get(pk=int(val))


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
