### PR TITLE
adds finished_at to the history page and adds TIMEZONE to the .env file

### DIFF
--- a/docs/18-webserver.md
+++ b/docs/18-webserver.md
@@ -62,9 +62,12 @@ In the `.env` file, ensure the following variables are set for production:
 DEBUG=False
 ALLOWED_HOSTS=*
 CSRF_TRUSTED_ORIGINS=https://yourdomain.com
+TIME_ZONE=America/Sao_Paulo
 
 MACHADO_VALID_TYPES=gene,mRNA,polypeptide
 ```
+
+Set `TIME_ZONE` to the server's actual timezone (defaults to `UTC` if unset). Django applies it at process startup, so it also determines what wall-clock time is recorded for timestamps such as the loader's command history — a mismatch here makes those timestamps look off relative to the server's local clock.
 
 If you are running more than one machado instance on the same machine — for
 example, several instances mounted at different Apache subpaths on the same

--- a/machado/project_template/machadoproject/settings.py
+++ b/machado/project_template/machadoproject/settings.py
@@ -85,7 +85,7 @@ DATABASES = {"default": env.db()}
 
 # ── Internationalization ─────────────────────────────────────────────────────
 LANGUAGE_CODE = "en-us"
-TIME_ZONE = "UTC"
+TIME_ZONE = env("TIME_ZONE", default="UTC")
 USE_I18N = True
 
 # ── Static files ─────────────────────────────────────────────────────────────

--- a/machado/scripts/startproject.py
+++ b/machado/scripts/startproject.py
@@ -27,6 +27,7 @@ DATABASE_URL=postgres://username:password@localhost:5432/yourdatabase
 # CSRF_TRUSTED_ORIGINS=https://example.com
 # STATIC_URL=/static/
 # STATIC_ROOT=staticfiles
+# TIME_ZONE=UTC
 
 # ── Multi-instance deployment (optional) ─────────────────────────────────────
 # Set this instance's mount path when running more than one machado instance

--- a/machado/templates/loader/history.html
+++ b/machado/templates/loader/history.html
@@ -38,6 +38,7 @@
                 <th class="border-top-0">Command</th>
                 <th class="border-top-0">PID</th>
                 <th class="border-top-0">Started At</th>
+                <th class="border-top-0">Finished At</th>
                 <th class="border-top-0">Status</th>
                 <th class="border-top-0 text-right">Logs</th>
               </tr>
@@ -49,6 +50,7 @@
                   <td><code class="text-primary font-weight-bold">{{ h.command }}</code></td>
                   <td><small class="text-muted">{% if h.pid %}{{ h.pid|stringformat:"d" }}{% else %}-{% endif %}</small></td>
                   <td><small class="text-muted">{{ h.created_at|date:"Y-m-d H:i:s" }}</small></td>
+                  <td><small class="text-muted">{% if h.finished_at %}{{ h.finished_at|date:"Y-m-d H:i:s" }}{% else %}-{% endif %}</small></td>
                   <td>
                     {% if h.status == "PENDING" %}
                       <span class="badge badge-secondary">Waiting</span>
@@ -104,7 +106,7 @@
                 </tr>
               {% empty %}
                 <tr>
-                  <td colspan="6" class="text-center py-4 text-muted">No loader history records found.</td>
+                  <td colspan="7" class="text-center py-4 text-muted">No loader history records found.</td>
                 </tr>
               {% endfor %}
             </tbody>


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
