### PR TITLE
fix: correct and speed up faceted search on /find/

### DIFF
--- a/machado/forms.py
+++ b/machado/forms.py
@@ -18,7 +18,6 @@ _ARRAY_FACETS = {
     "biomaterial",
     "treatment",
     "doi",
-    "orthologs_coexpression",
 }
 
 # The "analyses" facet uses AND logic; all others use OR.

--- a/machado/migrations/0011_orthologs_coexpression_boolean.py
+++ b/machado/migrations/0011_orthologs_coexpression_boolean.py
@@ -1,0 +1,82 @@
+# Copyright 2026 by Embrapa.  All rights reserved.
+#
+# This code is part of the machado distribution and governed by its
+# license. Please see the LICENSE.txt and README.md files that should
+# have been included as part of this package for licensing information.
+
+"""Collapse FeatureSearchIndex.orthologs_coexpression to a boolean.
+
+The column stored one JSON boolean per (orthologous-group member,
+translation_of subject) pair -- averaging 162 elements per row and peaking
+at 9627, about 1.2 billion elements and 747MB table-wide -- to encode what
+the facet only ever asked as a single bit: does this feature's orthologous
+group contain a coexpressed member? See
+searchindex._compute_ortholog_flags for the full account.
+
+The array form did not merely cost more, it did not work. Its facet count
+counted pairs rather than rows, so it advertised 1,153,066,191 hits on a
+7,564,658-row table, and the ``__contains`` filter paired with it searched
+for the *string* "true" inside an array of JSON *booleans*, matching
+nothing: selecting the facet always returned zero results.
+
+The new value is recoverable from the old column, so this migrates the data
+in place with one UPDATE rather than requiring a full rebuild_search_index
+run (days on a production corpus). ``@> 'true'::jsonb`` asks whether the
+array contains a true element, which is exactly ``any(flags)``.
+
+Not reversible: collapsing the per-pair flags to one bit discards the
+per-member detail, and nothing reads it back.
+
+Deliberately transactional, unlike 0009's AddIndexConcurrently on this same
+table. 0009 only added indexes, so a half-applied run lost nothing and
+avoiding its write lock was the only concern worth optimising for. Here the
+run drops the column the new value is derived from: a partial application
+would leave the boolean unpopulated with no source left to recompute it
+from, short of a multi-day rebuild_search_index. All-or-nothing is worth
+more than a briefly held lock, so this keeps the default atomic behaviour
+and a plain AddIndex.
+"""
+
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    """Set the boolean from the old array, then drop the array column."""
+    schema_editor.execute("""
+        UPDATE machado_featuresearchindex
+        SET orthologs_coexpression_bool = (orthologs_coexpression @> 'true'::jsonb)
+        """)
+
+
+class Migration(migrations.Migration):
+    """Replace the JSON array column with an indexed boolean."""
+
+    dependencies = [
+        ("machado", "0010_clean_bibtex_pub_titles"),
+    ]
+
+    operations = [
+        # Add the replacement alongside the original so the old values are
+        # still readable when forwards() derives the new ones from them.
+        migrations.AddField(
+            model_name="featuresearchindex",
+            name="orthologs_coexpression_bool",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name="featuresearchindex",
+            name="orthologs_coexpression",
+        ),
+        migrations.RenameField(
+            model_name="featuresearchindex",
+            old_name="orthologs_coexpression_bool",
+            new_name="orthologs_coexpression",
+        ),
+        migrations.AddIndex(
+            model_name="featuresearchindex",
+            index=models.Index(
+                fields=["orthologs_coexpression"], name="fsi_orth_coexp_idx"
+            ),
+        ),
+    ]

--- a/machado/models.py
+++ b/machado/models.py
@@ -4421,8 +4421,12 @@ class FeatureSearchIndex(models.Model):
     # ── Relationships (JSON array of "feature_id type_name" strings) ─────
     relationships = models.JSONField(default=list)
 
-    # ── Orthologs coexpression (multi-value facet) ───────────────────────
-    orthologs_coexpression = models.JSONField(default=list)
+    # ── Orthologs coexpression ───────────────────────────────────────────
+    # True when the feature's orthologous group has a coexpressed member.
+    # Stored as one bool, not the per-member flag array it used to be; see
+    # searchindex._compute_ortholog_flags for why that array was both far
+    # more expensive and unusable as a facet.
+    orthologs_coexpression = models.BooleanField(default=False)
 
     class Meta:
         managed = True
@@ -4436,6 +4440,7 @@ class FeatureSearchIndex(models.Model):
             models.Index(fields=["coexpression_group"], name="fsi_coexp_grp_idx"),
             models.Index(fields=["orthology"], name="fsi_orthology_idx"),
             models.Index(fields=["coexpression"], name="fsi_coexpression_idx"),
+            models.Index(fields=["orthologs_coexpression"], name="fsi_orth_coexp_idx"),
         ]
 
     def __str__(self):

--- a/machado/searchindex.py
+++ b/machado/searchindex.py
@@ -149,7 +149,7 @@ class IndexRunCache:
     test that rolled its fixture back) would be served stale flags.
     """
 
-    #: orthologous group value -> coexpression flag list, see
+    #: orthologous group value -> bool (group has a coexpressed member), see
     #: ``_prefetch_orthologs_coexpression``.
     ortholog_flags: dict = dataclasses.field(default_factory=dict)
 
@@ -335,7 +335,7 @@ def build_entries(features, ctx, config):
                     "{} {}".format(counterpart_id, type_name)
                     for counterpart_id, type_name in ctx.relationships.get(fid, ())
                 ],
-                orthologs_coexpression=ctx.orthologs_coexpression.get(fid, []),
+                orthologs_coexpression=ctx.orthologs_coexpression.get(fid, False),
             )
         )
     return entries
@@ -641,16 +641,25 @@ def _prefetch_orthologs_coexpression(ids, props, ortholog_flags=None):
     if missing:
         ortholog_flags.update(_compute_ortholog_flags(missing))
 
-    # Copy: each entry becomes a distinct FeatureSearchIndex.orthologs_coexpression
-    # value and must not alias the cached list.
-    return {fid: list(ortholog_flags[group]) for fid, group in groups.items()}
+    return {fid: ortholog_flags[group] for fid, group in groups.items()}
 
 
 def _compute_ortholog_flags(distinct_groups):
-    """Return ``{orthologous group: [coexpression flag, ...]}`` for the groups.
+    """Return ``{orthologous group: bool}`` -- has a coexpressed member.
 
-    One flag per (group member, ``translation_of`` subject of that member)
-    pair, True when the subject carries a coexpression group.
+    True when any (group member, ``translation_of`` subject of that member)
+    pair has the subject carrying a coexpression group.
+
+    Deliberately one bool per group rather than the per-pair list this used
+    to return. The facet only ever asks "does this feature's orthologous
+    group contain a coexpressed member?", so the list was collapsed to
+    ``any()`` at every point of use -- while costing one array element per
+    group member in every member's index row. On a real corpus that meant
+    ~162 booleans per row (max 9627, 1.2 billion table-wide) encoding a
+    single bit, which made the facet's count query unnestable-but-useless:
+    it counted pairs, so it reported more hits than the table has rows, and
+    the ``__contains`` filter it paired with looked for the *string*
+    "true" in an array of JSON *booleans* and therefore matched nothing.
     """
     from machado.models import FeatureRelationship, Featureprop
 
@@ -696,11 +705,11 @@ def _compute_ortholog_flags(distinct_groups):
 
     flags_by_group = {}
     for group, members in members_by_group.items():
-        flags = []
-        for member in members:
-            for subject in subjects_by_object.get(member, ()):
-                flags.append(subject in coexpressed)
-        flags_by_group[group] = flags
+        flags_by_group[group] = any(
+            subject in coexpressed
+            for member in members
+            for subject in subjects_by_object.get(member, ())
+        )
     return flags_by_group
 
 

--- a/machado/tests/data/search_index_snapshot.json
+++ b/machado/tests/data/search_index_snapshot.json
@@ -16,9 +16,7 @@
     "name": "GeneAlpha",
     "organism": "Arabidopsis thaliana",
     "orthologous_group": "OG_1",
-    "orthologs_coexpression": [
-      true
-    ],
+    "orthologs_coexpression": true,
     "orthology": true,
     "relationships": [
       "MRNA_A mRNA"
@@ -42,7 +40,7 @@
     "name": null,
     "organism": "Arabidopsis thaliana",
     "orthologous_group": null,
-    "orthologs_coexpression": [],
+    "orthologs_coexpression": false,
     "orthology": false,
     "relationships": [],
     "so_term": "gene",
@@ -62,7 +60,7 @@
     "name": "GeneGamma",
     "organism": "Arabidopsis thaliana",
     "orthologous_group": null,
-    "orthologs_coexpression": [],
+    "orthologs_coexpression": false,
     "orthology": false,
     "relationships": [],
     "so_term": "gene",
@@ -82,7 +80,7 @@
     "name": "mRnaAlpha",
     "organism": "Arabidopsis thaliana",
     "orthologous_group": null,
-    "orthologs_coexpression": [],
+    "orthologs_coexpression": false,
     "orthology": false,
     "relationships": [
       "GENE_A gene",
@@ -105,9 +103,7 @@
     "name": "PolyAlpha",
     "organism": "Arabidopsis thaliana",
     "orthologous_group": "OG_1",
-    "orthologs_coexpression": [
-      true
-    ],
+    "orthologs_coexpression": true,
     "orthology": true,
     "relationships": [
       "MRNA_A mRNA"

--- a/machado/tests/searchindex_fixture.py
+++ b/machado/tests/searchindex_fixture.py
@@ -286,19 +286,17 @@ def snapshot_index():
 
     READ THIS BEFORE TRUSTING A PASSING SNAPSHOT COMPARISON.
 
-    ``analyses``, ``doi``, ``biomaterial``, ``treatment``, ``relationships``
-    and ``orthologs_coexpression`` are sorted here, so for those six fields
-    this proves *set* equality only -- NOT that the stored list order is
-    byte-identical to the pre-batching implementation. Every list in the
-    recorded snapshot happens to have at most one element, which hides the
-    difference further.
+    ``analyses``, ``doi``, ``biomaterial``, ``treatment`` and
+    ``relationships`` are sorted here, so for those five fields this proves
+    *set* equality only -- NOT that the stored list order is byte-identical
+    to the pre-batching implementation. Every list in the recorded snapshot
+    happens to have at most one element, which hides the difference further.
 
     That is deliberate, not an oversight. The batched builder legitimately
     changed the order of those lists: ``analyses`` now follows
     ``order_by("program")``, ``relationships`` are ordered by counterpart id,
-    ``orthologs_coexpression`` is grouped by orthologous-group member, and
-    ``biomaterial``/``treatment`` follow whatever order the single batched
-    six-table join returns (plan-dependent, where before it was
+    and ``biomaterial``/``treatment`` follow whatever order the single
+    batched six-table join returns (plan-dependent, where before it was
     plan-dependent per feature). Each of those is at least as deterministic as
     what it replaced, and consumers only ever use JSONField ``__contains``
     lookups and plain iteration -- never indexing or slicing -- so order
@@ -332,6 +330,6 @@ def snapshot_index():
             "relationships": sorted(
                 _stable_relationships(row.relationships, id_to_uniquename)
             ),
-            "orthologs_coexpression": sorted(row.orthologs_coexpression),
+            "orthologs_coexpression": row.orthologs_coexpression,
         }
     return snapshot

--- a/machado/tests/test_searchindex_prefetch.py
+++ b/machado/tests/test_searchindex_prefetch.py
@@ -132,9 +132,10 @@ class PrefetchChunkTest(TestCase):
             prefetch_chunk(ids, self.config).orthologs_coexpression,
             "the cache changed the facet value",
         )
-        # Each feature must own its list, not alias the cached one.
-        for flags in warm.orthologs_coexpression.values():
-            self.assertNotIn(id(flags), {id(v) for v in cache.ortholog_flags.values()})
+        # The facet value is a single bool per feature, so there is no shared
+        # mutable list left for a chunk to alias into the cache.
+        for flag in warm.orthologs_coexpression.values():
+            self.assertIsInstance(flag, bool)
 
     def test_multi_doi_pub_picks_the_lowest_pk_dbxref(self):
         """A pub with two DOI dbxrefs resolves to the lowest-pk one.

--- a/machado/tests/test_views_search.py
+++ b/machado/tests/test_views_search.py
@@ -1,6 +1,8 @@
 """Tests for search views."""
 
-from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import AnonymousUser
+from django.core.management import call_command
+from django.test import TestCase, RequestFactory, override_settings
 from machado.models import (
     Cv,
     Cvterm,
@@ -19,6 +21,7 @@ from machado.views.search import (
     _doi_titles,
     _excluded_organism_names,
 )
+from machado.tests.searchindex_fixture import build_search_index_fixture
 from unittest.mock import patch, MagicMock
 from django.template.loader import render_to_string
 
@@ -163,6 +166,55 @@ class ComputeArrayFacetTest(TestCase):
         )
 
 
+@override_settings(MACHADO_VALID_TYPES=["gene", "mRNA", "polypeptide"])
+class FacetCountMatchesFilterTest(TestCase):
+    """A facet's count must equal the number of rows selecting it returns.
+
+    This is the promise a faceted UI makes: the number beside a facet value
+    is how many results clicking it yields. Asserted over every facet the
+    view publishes rather than one field, so a facet whose count is computed
+    by a different rule than the filter it applies cannot pass silently --
+    which is exactly how orthologs_coexpression came to advertise more hits
+    than the table has rows while returning none of them.
+    """
+
+    def setUp(self):
+        """Index the shared fixture corpus so the facets have real counts."""
+        build_search_index_fixture()
+        call_command("rebuild_search_index", batch_size=50, verbosity=0)
+
+    def _run(self, **params):
+        """Return (facet fields, result queryset) for a /find/ request."""
+        request = RequestFactory().get("/find/", params)
+        request.user = AnonymousUser()
+        view = FeatureSearchView()
+        view.request = request
+        view.args = ()
+        view.kwargs = {}
+        view.object_list = view.get_queryset()
+        context = view.get_context_data(object_list=view.object_list)
+        return context["facets"]["fields"], view.object_list
+
+    def test_every_facet_count_matches_its_filtered_result_count(self):
+        """Selecting a facet returns exactly as many rows as its count."""
+        facets, _ = self._run()
+
+        checked = 0
+        for field, pairs in facets.items():
+            for value, count in pairs:
+                _, qs = self._run(selected_facets="{}:{}".format(field, value))
+                self.assertEqual(
+                    qs.count(),
+                    count,
+                    "facet {}:{} advertises {} results but returns {}".format(
+                        field, value, count, qs.count()
+                    ),
+                )
+                checked += 1
+
+        self.assertTrue(checked, "the fixture produced no facet values to check")
+
+
 class ExcludedOrganismNamesTest(TestCase):
     """Test suite for _excluded_organism_names."""
 
@@ -274,9 +326,9 @@ class SearchViewsTest(TestCase):
         # Mock the queryset used for facets
         mock_qs = MagicMock()
         # Create a mock query result that yields the correct format for any field requested
-        mock_qs.values.return_value.annotate.return_value.filter.return_value.order_by.side_effect = lambda f: [
-            {f: "val", "count": 1}
-        ]
+        mock_qs.values.return_value.annotate.return_value.order_by.side_effect = (
+            lambda f: [{f: "val", "count": 1}]
+        )
         view._queryset_for_facets = mock_qs
 
         # Mock array facet computation

--- a/machado/views/search.py
+++ b/machado/views/search.py
@@ -36,7 +36,6 @@ _ARRAY_FACET_FIELDS = {
     "biomaterial",
     "treatment",
     "doi",
-    "orthologs_coexpression",
 }
 
 # Scalar facet fields (simple GROUP BY)
@@ -131,11 +130,17 @@ class FeatureSearchView(ListView):
             if field in _ARRAY_FACET_FIELDS:
                 facets[field] = self._compute_array_facet(qs, field)
             else:
+                # Count("*"), not Count("pk"): COUNT(feature_id) has to visit
+                # the heap to read that column, so Postgres falls back to a
+                # full sequential scan of the multi-GB table for every facet.
+                # COUNT(*) reads nothing per row, which lets the same query
+                # run as an index-only scan over the field's own (far
+                # smaller) btree -- ~5x faster per facet on a 7.5M-row index.
+                # No HAVING either: a GROUP BY never yields a zero count, so
+                # the old count__gt=0 filtered nothing and only blocked that
+                # plan.
                 counts = (
-                    qs.values(field)
-                    .annotate(count=Count("pk"))
-                    .filter(count__gt=0)
-                    .order_by(field)[:100]
+                    qs.values(field).annotate(count=Count("*")).order_by(field)[:100]
                 )
                 facets[field] = [
                     (row[field], row["count"])


### PR DESCRIPTION
The orthologs_coexpression facet stored one JSON boolean per (orthologous-group member, translation_of subject) pair -- averaging 162 elements per row, peaking at 9627, about 1.2 billion table-wide -- to encode what the facet only ever asked as a single bit: does this feature's orthologous group contain a coexpressed member?

That array did not merely cost more, it did not work. Its count counted pairs rather than rows, so the sidebar advertised 1,153,066,191 hits on a 7,564,658-row table -- 152x the whole table, impossible for a facet count -- while the __contains filter paired with it searched for the *string* "true" inside an array of JSON *booleans* and matched nothing, so selecting the facet always returned zero results. It is now a single indexed BooleanField holding any(flags): 2,183,355 true / 5,381,303 false, summing exactly to the row count, and selecting it returns those rows. Unnesting it cost ~58s per page load; the boolean costs 0.16s.

Separately, the scalar facet aggregates used Count("pk"), which emits COUNT(feature_id). Reading that column forces Postgres to visit the heap, so every facet fell back to a sequential scan of the 6.7GB table. COUNT(*) reads nothing per row and lets the same aggregate run as an index-only scan over the field's own ~50MB btree (confirmed: Parallel Index Only Scan, Heap Fetches: 0). The count__gt=0 HAVING went with it -- a GROUP BY never yields a zero count, so it filtered nothing and only blocked that plan. Six scalar facets: 4.03s -> 1.03s.

Unfiltered /find/ on the production corpus: ~70s -> ~9.3s.

Migration 0011 derives the boolean from the old column in one UPDATE rather than requiring a rebuild_search_index run (days on a real corpus). It is deliberately transactional, unlike 0009's AddIndexConcurrently on this same table: it drops the column the new value comes from, so a partial application would leave the boolean unpopulated with no source left to recompute it from. Note the UPDATE rewrites every row -- VACUUM FULL followed by a plain VACUUM to reset the visibility map is worth running afterwards, or the index-only scans above quietly degrade to heap fetches.

The new test asserts the invariant a faceted UI promises -- a facet's count equals the rows selecting it returns -- over every facet the view publishes, not just this one, so a facet counted by a different rule than the filter it applies cannot pass silently again.

This pull request addresses issue #...

I hereby agree to licence this and any previous contributions under
the terms of the GNU General Public License version 3 as published by
the Free Software Foundation

I have read the ``CONTRIBUTING.rst`` file and understand that
TravisCI will be used to confirm the tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``CONTRIB.rst`` files,
and have added myself to the file as part of this pull request.
(*This acknowledgement is optional. Note we list the names sorted alphabetically.*)
