### PR TITLE
Cache rendered search pages until the index is rebuilt

### DIFF
--- a/docs/16-visualization.md
+++ b/docs/16-visualization.md
@@ -5,4 +5,4 @@ The machado web interface requires the installation and configuration of third p
 - [Index and Search](17-index-search.md) — PostgreSQL full-text search
 - [Web Server](18-webserver.md) — Development server and Apache WSGI deployment
 - [JBrowse](19-jbrowse.md) — Genome browser integration (optional)
-- [Cache](20-cache.md) — Caching configuration (optional)
+- [Cache](20-cache.md) — Caching configuration

--- a/docs/17-index-search.md
+++ b/docs/17-index-search.md
@@ -23,9 +23,8 @@ python manage.py rebuild_search_index
 > **Note:** It is necessary to run `rebuild_search_index` whenever additional data is loaded into the database or when you wish to refresh the search facets.
 
 Rebuilding also clears the page cache, which is what makes newly loaded data
-visible on the search page — cached search pages never expire on their own.
-This only works with a shared cache backend, since the command runs in a
-different process from the web server; see [Cache](20-cache.md).
+visible on the search page. See [Cache](20-cache.md) for its one requirement,
+a writable cache directory.
 
 Rebuilding the index walks the features in chunks: for each chunk it issues a
 fixed, small number of queries for all the related data the chunk needs, then

--- a/docs/17-index-search.md
+++ b/docs/17-index-search.md
@@ -22,6 +22,11 @@ python manage.py rebuild_search_index
 
 > **Note:** It is necessary to run `rebuild_search_index` whenever additional data is loaded into the database or when you wish to refresh the search facets.
 
+Rebuilding also clears the page cache, which is what makes newly loaded data
+visible on the search page — cached search pages never expire on their own.
+This only works with a shared cache backend, since the command runs in a
+different process from the web server; see [Cache](20-cache.md).
+
 Rebuilding the index walks the features in chunks: for each chunk it issues a
 fixed, small number of queries for all the related data the chunk needs, then
 bulk-inserts that chunk's rows. `--batch-size` sets the size of that chunk, so

--- a/docs/20-cache.md
+++ b/docs/20-cache.md
@@ -26,18 +26,10 @@ sudo install -d -o www-data -g www-data -m 2775 /var/cache/machado
 sudo usermod -aG www-data $USER   # so you can run rebuild_search_index too
 ```
 
-Then set it in `.env`:
+A cache directory left inside the project tree (the default) will not be
+writable by Apache if the project is owned by another user, so on a
+production install set `CACHE_DIR` to a path outside it:
 
 ```
 CACHE_DIR=/var/cache/machado
 ```
-
-## Apache
-
-Under mod_wsgi the application runs as the Apache user — `www-data` on
-Debian/Ubuntu — unless `WSGIDaemonProcess` sets `user=`. That is the user
-that must own the cache directory above. See [Web server](18-webserver.md).
-
-A cache directory left inside the project tree (the default) will not be
-writable by Apache if the project is owned by another user, so on a
-production install set `CACHE_DIR` to a path outside it.

--- a/docs/20-cache.md
+++ b/docs/20-cache.md
@@ -1,46 +1,124 @@
-# Cache (optional)
+# Cache
 
-The machado views are pre-configured to enable local-memory caching for 1 hour. In order to move the cache to another location, you'll need to set Django's cache framework following the [official instructions](https://docs.djangoproject.com/en/5.2/topics/cache/).
+Two different things are cached, on two different schedules.
 
-## Example
+| What | Expires | Invalidated by |
+|---|---|---|
+| The search page (`/find/`) | never | `rebuild_search_index` |
+| The JBrowse API views | after `CACHE_TIMEOUT` (1 hour by default) | time only |
 
-Include the following in `settings.py` to store the cache in the database:
+The search page is cached because it is expensive to assemble: eleven facet
+aggregates over a multi-million-row index. On a 7.5M-feature corpus it takes
+about 4.2s to build and 0.013s to serve from cache.
+
+It never expires on its own because it does not need to. The corpus is
+read-only between index rebuilds, so a rendered page stays correct until the
+index changes — and `rebuild_search_index` clears the cache itself, both when
+it starts (the old index is being replaced) and when it finishes.
+
+## You must configure a shared cache backend
+
+This is the one part that is not optional.
+
+Django's default is `LocMemCache`, which is **per-process**.
+`rebuild_search_index` runs in a different process from the web workers, so
+with `LocMemCache` its `cache.clear()` cannot reach what they have cached.
+Because search pages never expire on their own, the result is that **stale
+search results are served indefinitely** after loading new data — until the
+web server is restarted.
+
+`LocMemCache` also holds only 300 entries by default and starts from empty in
+every worker, so it caches far less than you would expect.
+
+## Recommended configuration
+
+`FileBasedCache` needs no extra server and is the only built-in backend that
+compresses what it stores. These pages compress about 130× — a 1.8MB search
+page occupies roughly 36KB on disk.
+
+Add to `settings.py`:
 
 ```python
 CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
-        'LOCATION': 'machado_cache_table',
+    "default": {
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": "/var/cache/machado",
+        "TIMEOUT": None,          # search pages are invalidated by events, not time
+        "OPTIONS": {"MAX_ENTRIES": 1000000},
     }
 }
-CACHE_TIMEOUT = 60 * 60 * 24  # 86400 seconds == 1 day
 ```
 
-Create the cache table:
+### `MAX_ENTRIES` is not optional either
+
+Leaving it out does not mean "no limit" — it means **300**, and every write
+past that deletes a third of the cache. Set it high enough that it never
+triggers in practice.
+
+### Directory permissions
+
+The cache directory is written by the web server and cleared by
+`rebuild_search_index`. If those run as different users, clearing fails with
+a permission error. Either run the command as the web server's user, or give
+both a shared group with group-write on the directory:
+
+```bash
+sudo install -d -o www-data -g machado -m 2775 /var/cache/machado
+```
+
+Django creates the directory mode `0700` if it does not exist, which is
+owner-only — so create it yourself if two users need it.
+
+## Alternative: `DatabaseCache`
+
+Also serverless, and immune to the permission problem above because both
+processes reach it through the database. The tradeoff is size: it
+base64-encodes what it stores instead of compressing, so the same 1.8MB page
+becomes about 2.4MB rather than 36KB — roughly 150× more storage for
+identical content.
+
+```python
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "machado_cache_table",
+        "TIMEOUT": None,
+        "OPTIONS": {"MAX_ENTRIES": 50000},
+    }
+}
+```
 
 ```bash
 python manage.py createcachetable
 ```
 
-## Clearing the Cache Table
+Note this writes to the database, so it is incompatible with making the
+database read-only after going live.
 
-It is a good idea to clear the cache table whenever you make changes to your machado installation. For this, install the [django-clear-cache](https://github.com/rdegges/django-clear-cache) tool:
+## Clearing the cache manually
 
-```bash
-pip install django-clear-cache
-```
-
-Then modify your `settings.py` file to add `clear_cache`:
-
-```python
-INSTALLED_APPS = (
-    # ...
-    'clear_cache',
-)
-```
-
-Then to clear the cache just run:
+`rebuild_search_index` already clears it, so this is only needed after
+changing templates, settings, or anything else the cache cannot know about:
 
 ```bash
-python manage.py clear_cache
+python manage.py shell -c "from django.core.cache import cache; cache.clear()"
 ```
+
+## What the search page cache is keyed on
+
+The URL path, the query string, and whether the visitor is logged in.
+
+Anonymous visitors and authenticated users never share an entry: an
+anonymous visitor has private organisms filtered out of results and facet
+counts, so serving one audience the other's page would disclose data.
+Nothing finer is needed — visibility depends on being logged in, never on
+*which* user, so all authenticated users share a single entry.
+
+Query strings are normalised, so ticking the same facets in a different
+order reuses one entry rather than storing several copies of the same page.
+
+Only `GET` requests and only successful (200) responses are stored, so an
+error page is never served to everyone until the next rebuild.
+
+The export endpoint (`/export/`) is deliberately not cached: it is
+unpaginated, so a single response can be the entire result set.

--- a/docs/20-cache.md
+++ b/docs/20-cache.md
@@ -1,124 +1,43 @@
 # Cache
 
-Two different things are cached, on two different schedules.
+Rendered search pages are cached on disk and cleared automatically by
+`rebuild_search_index`. There is nothing to enable and no cache to clear by
+hand — the only setup is the cache directory and its permissions.
 
-| What | Expires | Invalidated by |
+## Settings
+
+`machado-startproject` writes these into `.env`, commented out. The defaults
+work; uncomment only what you need to change.
+
+| Variable | Default | Purpose |
 |---|---|---|
-| The search page (`/find/`) | never | `rebuild_search_index` |
-| The JBrowse API views | after `CACHE_TIMEOUT` (1 hour by default) | time only |
+| `CACHE_DIR` | `cache` beside `manage.py` | Where the cache files are written |
+| `CACHE_MAX_ENTRIES` | `1000000` | Effectively no limit. Django's own default is 300, and every write past the limit deletes a third of the cache |
+| `CACHE_TIMEOUT` | `3600` | How long the JBrowse API views stay cached, in seconds. Does not affect search pages, which are cleared by `rebuild_search_index` rather than by time |
 
-The search page is cached because it is expensive to assemble: eleven facet
-aggregates over a multi-million-row index. On a 7.5M-feature corpus it takes
-about 4.2s to build and 0.013s to serve from cache.
+## Directory permissions
 
-It never expires on its own because it does not need to. The corpus is
-read-only between index rebuilds, so a rendered page stays correct until the
-index changes — and `rebuild_search_index` clears the cache itself, both when
-it starts (the old index is being replaced) and when it finishes.
-
-## You must configure a shared cache backend
-
-This is the one part that is not optional.
-
-Django's default is `LocMemCache`, which is **per-process**.
-`rebuild_search_index` runs in a different process from the web workers, so
-with `LocMemCache` its `cache.clear()` cannot reach what they have cached.
-Because search pages never expire on their own, the result is that **stale
-search results are served indefinitely** after loading new data — until the
-web server is restarted.
-
-`LocMemCache` also holds only 300 entries by default and starts from empty in
-every worker, so it caches far less than you would expect.
-
-## Recommended configuration
-
-`FileBasedCache` needs no extra server and is the only built-in backend that
-compresses what it stores. These pages compress about 130× — a 1.8MB search
-page occupies roughly 36KB on disk.
-
-Add to `settings.py`:
-
-```python
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": "/var/cache/machado",
-        "TIMEOUT": None,          # search pages are invalidated by events, not time
-        "OPTIONS": {"MAX_ENTRIES": 1000000},
-    }
-}
-```
-
-### `MAX_ENTRIES` is not optional either
-
-Leaving it out does not mean "no limit" — it means **300**, and every write
-past that deletes a third of the cache. Set it high enough that it never
-triggers in practice.
-
-### Directory permissions
-
-The cache directory is written by the web server and cleared by
-`rebuild_search_index`. If those run as different users, clearing fails with
-a permission error. Either run the command as the web server's user, or give
-both a shared group with group-write on the directory:
+The directory is written by Apache and cleared by `rebuild_search_index`, so
+both need write access. If Django creates it, it will be mode `0700` and
+owned by whichever of the two ran first — so create it explicitly:
 
 ```bash
-sudo install -d -o www-data -g machado -m 2775 /var/cache/machado
+sudo install -d -o www-data -g www-data -m 2775 /var/cache/machado
+sudo usermod -aG www-data $USER   # so you can run rebuild_search_index too
 ```
 
-Django creates the directory mode `0700` if it does not exist, which is
-owner-only — so create it yourself if two users need it.
+Then set it in `.env`:
 
-## Alternative: `DatabaseCache`
-
-Also serverless, and immune to the permission problem above because both
-processes reach it through the database. The tradeoff is size: it
-base64-encodes what it stores instead of compressing, so the same 1.8MB page
-becomes about 2.4MB rather than 36KB — roughly 150× more storage for
-identical content.
-
-```python
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "machado_cache_table",
-        "TIMEOUT": None,
-        "OPTIONS": {"MAX_ENTRIES": 50000},
-    }
-}
+```
+CACHE_DIR=/var/cache/machado
 ```
 
-```bash
-python manage.py createcachetable
-```
+## Apache
 
-Note this writes to the database, so it is incompatible with making the
-database read-only after going live.
+Under mod_wsgi the application runs as the Apache user — `www-data` on
+Debian/Ubuntu — unless `WSGIDaemonProcess` sets `user=`. That is the user
+that must own the cache directory above. See [Web server](18-webserver.md).
 
-## Clearing the cache manually
-
-`rebuild_search_index` already clears it, so this is only needed after
-changing templates, settings, or anything else the cache cannot know about:
-
-```bash
-python manage.py shell -c "from django.core.cache import cache; cache.clear()"
-```
-
-## What the search page cache is keyed on
-
-The URL path, the query string, and whether the visitor is logged in.
-
-Anonymous visitors and authenticated users never share an entry: an
-anonymous visitor has private organisms filtered out of results and facet
-counts, so serving one audience the other's page would disclose data.
-Nothing finer is needed — visibility depends on being logged in, never on
-*which* user, so all authenticated users share a single entry.
-
-Query strings are normalised, so ticking the same facets in a different
-order reuses one entry rather than storing several copies of the same page.
-
-Only `GET` requests and only successful (200) responses are stored, so an
-error page is never served to everyone until the next rebuild.
-
-The export endpoint (`/export/`) is deliberately not cached: it is
-unpaginated, so a single response can be the entire result set.
+A cache directory left inside the project tree (the default) will not be
+writable by Apache if the project is owned by another user, so on a
+production install set `CACHE_DIR` to a path outside it.

--- a/machado/caching.py
+++ b/machado/caching.py
@@ -1,0 +1,107 @@
+# Copyright 2018 by Embrapa.  All rights reserved.
+#
+# This code is part of the machado distribution and governed by its
+# license. Please see the LICENSE.txt and README.md files that should
+# have been included as part of this package for licensing information.
+"""Whole-page caching for the read-heavy search views.
+
+The corpus is loaded once and then only read, so a rendered page stays
+correct until the search index is rebuilt -- which is the only event that
+invalidates anything (see the ``cache.clear()`` calls in
+``rebuild_search_index``). Entries therefore never expire on their own.
+"""
+
+import functools
+import hashlib
+
+from django.core.cache import cache
+from django.http import HttpResponse
+
+#: Bumped only if the stored representation changes shape, so an old cache
+#: cannot be misread as a new one.
+_CACHE_VERSION = "v1"
+
+
+def _is_authenticated(request):
+    """Whether the request comes from a logged-in user."""
+    user = getattr(request, "user", None)
+    return bool(user and user.is_authenticated)
+
+
+def page_cache_key(request, authenticated):
+    """Build the cache key for one rendered page.
+
+    Query parameters are sorted, and their values sorted within each
+    parameter, so requests that mean the same thing share one entry:
+    ``selected_facets`` arrives in whatever order the user happened to tick
+    the boxes, and ``?a=1&b=2`` is the same page as ``?b=2&a=1``. Django's
+    own ``cache_page`` keys on the raw URL and would store those separately.
+
+    ``authenticated`` is part of the key because anonymous and logged-in
+    users see different result sets -- an anonymous visitor has private
+    organisms filtered out (see ``_excluded_organism_names``). Nothing
+    finer is needed: visibility turns on ``is_authenticated`` alone, never
+    on which user, so all logged-in users share one entry.
+
+    Deliberately NOT keyed on cookies, even though these responses carry
+    ``Vary: Cookie``. Honouring that -- as ``cache_page`` would -- gives
+    every distinct cookie value its own entry, so each anonymous visitor
+    holding a ``csrftoken`` would miss and store a near-duplicate page.
+    The two buckets above are the only ones that differ in content.
+    """
+    params = sorted(
+        (name, sorted(request.GET.getlist(name))) for name in request.GET.keys()
+    )
+    raw = repr((_CACHE_VERSION, request.path, params, authenticated))
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return "machado.page.{}.{}".format(
+        "auth" if authenticated else "anon",
+        digest,
+    )
+
+
+def cache_page_per_auth(view):
+    """Cache a view's rendered output, separately for the two audiences.
+
+    Only GET requests, and only successful responses, are stored. A
+    ``TemplateResponse`` is not rendered when the view returns it, so
+    storing is deferred to a post-render callback -- otherwise ``.content``
+    raises and nothing would ever be cached.
+    """
+
+    @functools.wraps(view)
+    def wrapper(request, *args, **kwargs):
+        if request.method != "GET":
+            return view(request, *args, **kwargs)
+
+        authenticated = _is_authenticated(request)
+        key = page_cache_key(request, authenticated)
+
+        hit = cache.get(key)
+        if hit is not None:
+            return HttpResponse(
+                hit["content"],
+                content_type=hit["content_type"],
+            )
+
+        response = view(request, *args, **kwargs)
+
+        def store(rendered):
+            if rendered.status_code == 200:
+                cache.set(
+                    key,
+                    {
+                        "content": rendered.content,
+                        "content_type": rendered.get("Content-Type"),
+                    },
+                    timeout=None,
+                )
+            return rendered
+
+        if hasattr(response, "add_post_render_callback"):
+            response.add_post_render_callback(store)
+        else:
+            store(response)
+        return response
+
+    return wrapper

--- a/machado/management/commands/rebuild_search_index.py
+++ b/machado/management/commands/rebuild_search_index.py
@@ -20,6 +20,7 @@ features rather than per feature), which is what makes a multi-million-row
 rebuild practical.
 """
 
+from django.core.cache import cache as page_cache
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from django.db.models import Max
@@ -115,6 +116,16 @@ class Command(HistoryCommandMixin, BaseCommand):
         else:
             self.clear_index()
 
+        # Cleared here as well as on the way out, and deliberately so: the
+        # cached pages describe an index that clear_index() has just
+        # truncated (or that this run is about to add rows to), so they are
+        # already wrong. Leaving them until the end would serve stale
+        # results for however long the rebuild takes -- hours on a real
+        # corpus -- and would leave them stale indefinitely if the run then
+        # failed. Machado's page cache never expires on its own, so a
+        # rebuild is the only thing that can invalidate it.
+        page_cache.clear()
+
         total = self.count_remaining(config, start_after)
         if limit is not None:
             total = min(total, limit)
@@ -172,6 +183,10 @@ class Command(HistoryCommandMixin, BaseCommand):
             raise
         finally:
             progress.close()
+            # In the finally block, not after it: an interrupted or failed
+            # run still leaves the index different from what the pages
+            # cached at the start of this run were rendered from.
+            page_cache.clear()
 
         self.report(
             self.style.SUCCESS(

--- a/machado/project_template/machadoproject/settings.py
+++ b/machado/project_template/machadoproject/settings.py
@@ -83,6 +83,37 @@ TEMPLATES = [
 # ── Database ─────────────────────────────────────────────────────────────────
 DATABASES = {"default": env.db()}
 
+# ── Cache ────────────────────────────────────────────────────────────────────
+# A shared backend is required, not merely preferable. Django's default
+# LocMemCache is per-process, and rebuild_search_index runs in a different
+# process from the web workers -- so it could not invalidate the pages they
+# have cached, and /find/ pages never expire on their own (see below).
+#
+# FileBasedCache rather than DatabaseCache: it is the only built-in backend
+# that compresses what it stores, and these pages compress about 130x (a
+# search page is ~1.8MB of largely repetitive HTML, stored in ~36KB).
+# DatabaseCache base64-encodes instead, inflating the same page to ~2.4MB.
+# Neither needs a separate server. See docs/20-cache.md.
+#
+# TIMEOUT None means entries never expire on their own: the corpus is
+# read-only between index rebuilds, so a rebuild is the only thing that
+# invalidates a page, and rebuild_search_index clears the cache itself.
+#
+# MAX_ENTRIES has to be stated. Omitting it does not mean "unlimited", it
+# means 300, and every write past that culls a third of the cache.
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": env("CACHE_DIR", default=str(BASE_DIR / "cache")),
+        "TIMEOUT": None,
+        "OPTIONS": {"MAX_ENTRIES": env.int("CACHE_MAX_ENTRIES", default=1000000)},
+    }
+}
+
+# How long the JBrowse API views are cached. Unrelated to the /find/ page
+# cache above, which is invalidated by rebuild_search_index rather than time.
+CACHE_TIMEOUT = env.int("CACHE_TIMEOUT", default=60 * 60)
+
 # ── Internationalization ─────────────────────────────────────────────────────
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = env("TIME_ZONE", default="UTC")

--- a/machado/scripts/startproject.py
+++ b/machado/scripts/startproject.py
@@ -43,6 +43,25 @@ DATABASE_URL=postgres://username:password@localhost:5432/yourdatabase
 # ── Feature types for search indexing (optional) ─────────────────────────────
 # MACHADO_VALID_TYPES=gene,mRNA,polypeptide
 
+# ── Cache (optional) ─────────────────────────────────────────────────────────
+# Rendered search pages are cached until the next rebuild_search_index run.
+# The defaults work as-is; the values below only tune them.
+#
+# Where the cache files live. Must be writable by the web server AND by
+# whoever runs rebuild_search_index -- if those are different users, create
+# the directory with a shared group rather than letting Django create it
+# 0700. Defaults to a "cache" directory beside manage.py.
+# CACHE_DIR=/var/cache/machado
+#
+# Effectively "no limit". Do not lower this without reading
+# docs/20-cache.md: Django's own default is 300 entries, and every write past
+# the limit deletes a third of the cache.
+# CACHE_MAX_ENTRIES=1000000
+#
+# How long the JBrowse API views stay cached, in seconds. Does not affect
+# search pages, which are invalidated by rebuild_search_index, not by time.
+# CACHE_TIMEOUT=3600
+
 # ── Landing page customization (optional) ────────────────────────────────────
 # All values below have sensible defaults; override only what you need.
 # A feature-card, how-it-works-heading, how-it-works-step, features-section,

--- a/machado/tests/test_caching.py
+++ b/machado/tests/test_caching.py
@@ -1,0 +1,161 @@
+# Copyright 2026 by Embrapa.  All rights reserved.
+#
+# This code is part of the machado distribution and governed by its
+# license. Please see the LICENSE.txt and README.md files that should
+# have been included as part of this package for licensing information.
+
+"""Tests for whole-page caching of the search views."""
+
+import tempfile
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from machado.caching import cache_page_per_auth, page_cache_key
+
+FILE_CACHE = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": tempfile.mkdtemp(prefix="machado-test-cache-"),
+        "TIMEOUT": None,
+        "OPTIONS": {"MAX_ENTRIES": 10000},
+    }
+}
+
+
+@override_settings(CACHES=FILE_CACHE)
+class PageCacheKeyTest(TestCase):
+    """What the key does and does not distinguish."""
+
+    def setUp(self):
+        """Start from an empty cache."""
+        cache.clear()
+        self.factory = RequestFactory()
+
+    def _key(self, query, authenticated=False):
+        return page_cache_key(self.factory.get("/find/", query), authenticated)
+
+    def test_anonymous_and_authenticated_never_share_an_entry(self):
+        """The two audiences see different results, so they must not collide.
+
+        An anonymous visitor has private organisms filtered out. Sharing a
+        cache entry would serve them a page built for a logged-in user.
+        """
+        self.assertNotEqual(self._key({}, False), self._key({}, True))
+
+    def test_facet_order_does_not_split_the_entry(self):
+        """Ticking the same boxes in a different order is the same page."""
+        a = self._key({"selected_facets": ["organism:Zea mays", "so_term:gene"]})
+        b = self._key({"selected_facets": ["so_term:gene", "organism:Zea mays"]})
+        self.assertEqual(a, b)
+
+    def test_parameter_order_does_not_split_the_entry(self):
+        """?a=1&b=2 is the same page as ?b=2&a=1."""
+        self.assertEqual(
+            page_cache_key(self.factory.get("/find/?q=kinase&order_by=name"), False),
+            page_cache_key(self.factory.get("/find/?order_by=name&q=kinase"), False),
+        )
+
+    def test_different_queries_do_not_share_an_entry(self):
+        """Distinct searches are distinct pages."""
+        self.assertNotEqual(self._key({"q": "kinase"}), self._key({"q": "kinesin"}))
+
+    def test_different_facet_selections_do_not_share_an_entry(self):
+        """Selecting an extra facet is a different page."""
+        self.assertNotEqual(
+            self._key({"selected_facets": ["so_term:gene"]}),
+            self._key({"selected_facets": ["so_term:gene", "organism:Zea mays"]}),
+        )
+
+
+@override_settings(CACHES=FILE_CACHE)
+class CachePagePerAuthTest(TestCase):
+    """The decorator's behaviour around who gets served what."""
+
+    def setUp(self):
+        """Start from an empty cache with a counting view."""
+        cache.clear()
+        self.factory = RequestFactory()
+        self.calls = []
+
+        @cache_page_per_auth
+        def view(request):
+            self.calls.append(request)
+            who = "auth" if request.user.is_authenticated else "anon"
+            return HttpResponse(f"page for {who} #{len(self.calls)}")
+
+        self.view = view
+
+    def _get(self, user, **query):
+        request = self.factory.get("/find/", query)
+        request.user = user
+        return self.view(request)
+
+    def test_second_identical_request_is_served_from_cache(self):
+        """A repeat request must not reach the view again."""
+        first = self._get(AnonymousUser())
+        second = self._get(AnonymousUser())
+        self.assertEqual(first.content, second.content)
+        self.assertEqual(len(self.calls), 1, "the view ran twice")
+
+    def test_authenticated_user_does_not_receive_the_anonymous_page(self):
+        """The cached anonymous page must not leak to a logged-in user."""
+        anon_body = self._get(AnonymousUser()).content
+        user = User.objects.create_user(username="someone", password="pw")
+        auth_body = self._get(user).content
+
+        self.assertNotEqual(anon_body, auth_body)
+        self.assertIn(b"for auth", auth_body)
+        self.assertEqual(len(self.calls), 2, "the view should have run for each")
+
+    def test_anonymous_user_does_not_receive_the_authenticated_page(self):
+        """And the reverse: a logged-in page must not leak to anonymous."""
+        user = User.objects.create_user(username="someone", password="pw")
+        auth_body = self._get(user).content
+        anon_body = self._get(AnonymousUser()).content
+
+        self.assertNotEqual(auth_body, anon_body)
+        self.assertIn(b"for anon", anon_body)
+
+    def test_all_authenticated_users_share_one_entry(self):
+        """Visibility turns on is_authenticated, never on which user.
+
+        Keying per user would multiply the cache by the number of accounts
+        for no difference in content.
+        """
+        one = User.objects.create_user(username="one", password="pw")
+        two = User.objects.create_user(username="two", password="pw")
+        self.assertEqual(self._get(one).content, self._get(two).content)
+        self.assertEqual(len(self.calls), 1)
+
+    def test_post_is_not_cached(self):
+        """Only GET is cached."""
+        request = self.factory.post("/find/")
+        request.user = AnonymousUser()
+        self.view(request)
+        self.view(request)
+        self.assertEqual(len(self.calls), 2)
+
+    def test_error_responses_are_not_cached(self):
+        """A failure must not be served to everyone until the next rebuild."""
+        calls = []
+
+        @cache_page_per_auth
+        def failing(request):
+            calls.append(request)
+            return HttpResponse("boom", status=500)
+
+        request = self.factory.get("/find/")
+        request.user = AnonymousUser()
+        failing(request)
+        failing(request)
+        self.assertEqual(len(calls), 2, "a 500 was cached")
+
+    def test_clearing_the_cache_makes_the_view_run_again(self):
+        """This is what rebuild_search_index relies on for invalidation."""
+        self._get(AnonymousUser())
+        cache.clear()
+        self._get(AnonymousUser())
+        self.assertEqual(len(self.calls), 2)

--- a/machado/urls.py
+++ b/machado/urls.py
@@ -9,6 +9,7 @@
 from django.conf import settings
 from django.urls import re_path, path, include
 
+from machado.caching import cache_page_per_auth
 from machado.views import common
 
 try:
@@ -48,7 +49,11 @@ urlpatterns = [
     ),
     re_path(
         r"^find/$",
-        search.FeatureSearchView.as_view(),
+        # Cached whole-page: the corpus is read-only between index rebuilds,
+        # and this page costs seconds to assemble (eleven facet aggregates
+        # over a multi-million-row index). Export is left uncached -- it is
+        # unpaginated, so a single response can be the whole result set.
+        cache_page_per_auth(search.FeatureSearchView.as_view()),
         name="feature_search",
     ),
     re_path(


### PR DESCRIPTION
Caches rendered search pages, so `/find/` is served from disk instead of being
reassembled on every request.

The corpus is read-only between index rebuilds, so a rendered page stays correct
until `rebuild_search_index` replaces the index. That makes invalidation a single
event rather than a policy, and entries never expire on their own.

Measured on a 7.5M-feature corpus: **4.19s cold, 0.013s warm.**

## How it is keyed

Hand-rolled rather than `@cache_page`, for two reasons:

* These responses carry `Vary: Cookie`, and `cache_page` folds `Vary` into its
  key — so every distinct cookie value would get its own entry, and each
  anonymous visitor holding a `csrftoken` would miss and store a near-duplicate
  of a ~1.8MB page.
* The key normalises the query string, sorting parameters and the values within
  each, so ticking the same facet boxes in a different order shares one entry.
  `cache_page` keys on the raw URL.

Keyed on `is_authenticated`, which is exactly as fine-grained as the data needs:
an anonymous visitor has private organisms filtered out, but visibility turns on
`is_authenticated` alone and never on *which* user (checked across the search,
feature and common views), so all logged-in users share one entry. Serving one
audience the other's page would disclose data, so the tests pin both directions.

Only `GET`, and only 200s, are stored — a 500 must not be served to everyone
until the next rebuild. `/export/` is left uncached: it is unpaginated, so one
response can be the entire result set.

## Invalidation

`rebuild_search_index` clears the cache twice: once up front, because
`clear_index()` has just truncated the index the cached pages were rendered from,
and once in a `finally` block, because an interrupted run still leaves the index
changed. Without the first, stale results would be served for the hours a real
rebuild takes — and indefinitely if the run then failed.

This is also why a **shared** cache backend is required rather than merely
preferable: the command is a different process from the web workers, and Django's
default `LocMemCache` is per-process, so it could never invalidate their pages.

## Backend

`project_template` ships `FileBasedCache`, the only built-in backend that
compresses what it stores. These pages compress about 130× — a 1.8MB page lands
in ~36KB on disk — where `DatabaseCache` base64-encodes and would inflate the
same page to ~2.4MB, roughly 150× more storage for identical content. Neither
needs a separate server.

`machado-startproject` writes `CACHE_DIR`, `CACHE_MAX_ENTRIES` and
`CACHE_TIMEOUT` into the generated `.env` and `.env.example`, so a new project
gets a working shared cache without reading the docs first. `CACHE_TIMEOUT` was
previously only reachable by hand-editing `settings.py`, despite `urls.py` and
`views/jbrowse.py` both already honouring it.

Two traps are documented because neither is discoverable: `MAX_ENTRIES` means
300 rather than "unlimited" when omitted, and the default cache directory sits
inside the project tree where Apache cannot write it.

## Tests

312 passing, 12 of them new — covering the key's behaviour, both leak directions
between audiences, that all authenticated users share an entry, that `POST` and
non-200 responses are not stored, and that clearing the cache makes the view run
again (the mechanism `rebuild_search_index` depends on).
